### PR TITLE
Screen Share Send Settings Demo with Multiple Quality Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,13 @@
 This project console logs every event listener for Daily React. This is a great
 way to debug exactly what events are fired when trying to reproduce an issue.
 
-## Features
-
-### Screen Share Send Settings Demo
-This branch (`demo/screenshare-send-settings`) demonstrates how to configure screen share resolution and bitrate settings using Daily.js:
-
-- **720p Screen Share**: 1280x720 resolution with optimized encoding layers
-- **1080p Screen Share**: 1920x1080 resolution with high-quality settings  
-- **Default Mode**: Uses Daily's motion-optimized preset
-
-#### Implementation Details
-- Uses `callObject.startScreenShare()` with custom `displayMediaOptions` and `screenVideoSendSettings`
-- Configures simulcast layers for optimal bandwidth usage
-- Provides real-time quality selection via dropdown interface
-- Console logs show detailed configuration for each quality mode
-
-#### Usage
-1. Select desired screen share quality from the dropdown
-2. Click "Start Screen Share" to begin with custom settings
-3. Monitor console output to see the applied configuration
-4. Compare bandwidth usage and visual quality between modes
-
 ## Available Scripts
 
 In the project directory, you can run:
 
-### `npm run dev`
+### `npm start`
 
-Runs the app in development mode with host binding.\
+Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 The page will reload if you make edits.\

--- a/README.md
+++ b/README.md
@@ -3,13 +3,34 @@
 This project console logs every event listener for Daily React. This is a great
 way to debug exactly what events are fired when trying to reproduce an issue.
 
+## Features
+
+### Screen Share Send Settings Demo
+This branch (`demo/screenshare-send-settings`) demonstrates how to configure screen share resolution and bitrate settings using Daily.js:
+
+- **720p Screen Share**: 1280x720 resolution with optimized encoding layers
+- **1080p Screen Share**: 1920x1080 resolution with high-quality settings  
+- **Default Mode**: Uses Daily's motion-optimized preset
+
+#### Implementation Details
+- Uses `callObject.startScreenShare()` with custom `displayMediaOptions` and `screenVideoSendSettings`
+- Configures simulcast layers for optimal bandwidth usage
+- Provides real-time quality selection via dropdown interface
+- Console logs show detailed configuration for each quality mode
+
+#### Usage
+1. Select desired screen share quality from the dropdown
+2. Click "Start Screen Share" to begin with custom settings
+3. Monitor console output to see the applied configuration
+4. Compare bandwidth usage and visual quality between modes
+
 ## Available Scripts
 
 In the project directory, you can run:
 
-### `npm start`
+### `npm run dev`
 
-Runs the app in the development mode.\
+Runs the app in development mode with host binding.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 The page will reload if you make edits.\

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,9 @@ export default function App() {
   const [enableBackgroundClicked, setEnableBackgroundClicked] = useState(false);
   const [dailyRoomUrl, setDailyRoomUrl] = useState("");
   const [dailyMeetingToken, setDailyMeetingToken] = useState("");
-  const [screenShareQuality, setScreenShareQuality] = useState<"720p" | "1080p" | "default">("720p");
+  const [screenShareQuality, setScreenShareQuality] = useState<
+    "480p" | "720p" | "1080p" | "default"
+  >("720p");
 
   const {
     cameraError,
@@ -112,16 +114,15 @@ export default function App() {
   const noiseCancellationEnabled =
     inputSettings?.audio?.processor?.type === "noise-cancellation";
 
-  const { stopScreenShare, screens, isSharingScreen } =
-    useScreenShare({
-      onError: logEvent,
-      onLocalScreenShareStarted: () => {
-        logEvent({ action: "local-screen-share-started" });
-      },
-      onLocalScreenShareStopped: () => {
-        logEvent({ action: "local-screen-share-stopped" });
-      },
-    });
+  const { stopScreenShare, screens, isSharingScreen } = useScreenShare({
+    onError: logEvent,
+    onLocalScreenShareStarted: () => {
+      logEvent({ action: "local-screen-share-started" });
+    },
+    onLocalScreenShareStopped: () => {
+      logEvent({ action: "local-screen-share-stopped" });
+    },
+  });
 
   const startCustomScreenShare = useCallback(() => {
     if (!callObject) {
@@ -135,6 +136,24 @@ export default function App() {
     let displayMediaOptions: any;
 
     switch (screenShareQuality) {
+      case "480p":
+        displayMediaOptions = {
+          video: {
+            width: { ideal: 854 },
+            height: { ideal: 480 },
+            frameRate: { ideal: 15 },
+          },
+          audio: true,
+        };
+        screenVideoSendSettings = {
+          low: {
+            maxBitrate: 600000, // 600 kbps for 480p
+            maxFramerate: 15,
+            scaleResolutionDownBy: 1, // Full 854x480 resolution
+          },
+          maxQuality: "low", // Only send the low layer
+        };
+        break;
       case "720p":
         displayMediaOptions = {
           video: {
@@ -146,7 +165,7 @@ export default function App() {
         };
         screenVideoSendSettings = {
           low: {
-            maxBitrate: 1200000, // 1.2 Mbps  
+            maxBitrate: 1200000, // 1.2 Mbps
             maxFramerate: 30,
             scaleResolutionDownBy: 1, // Full 1280x720 resolution
           },
@@ -637,8 +656,13 @@ export default function App() {
           Screen Share Quality:
           <select
             value={screenShareQuality}
-            onChange={(e) => setScreenShareQuality(e.target.value as "720p" | "1080p" | "default")}
+            onChange={(e) =>
+              setScreenShareQuality(
+                e.target.value as "480p" | "720p" | "1080p" | "default"
+              )
+            }
           >
+            <option value="480p">480p (854x480) - Low Bandwidth</option>
             <option value="720p">720p (1280x720)</option>
             <option value="1080p">1080p (1920x1080)</option>
             <option value="default">Default (Motion Optimized)</option>
@@ -653,7 +677,9 @@ export default function App() {
             }
           }}
         >
-          {isSharingScreen ? "Stop Screen Share" : `Start Screen Share (${screenShareQuality})`}
+          {isSharingScreen
+            ? "Stop Screen Share"
+            : `Start Screen Share (${screenShareQuality})`}
         </button>
         <br />
         <button onClick={stopCamera}>Camera Off</button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,16 +146,11 @@ export default function App() {
         };
         screenVideoSendSettings = {
           low: {
-            maxBitrate: 500000, // 500 kbps
-            maxFramerate: 15,
-            scaleResolutionDownBy: 2, // 640x360
-          },
-          medium: {
             maxBitrate: 1200000, // 1.2 Mbps  
             maxFramerate: 30,
-            scaleResolutionDownBy: 1, // 1280x720
+            scaleResolutionDownBy: 1, // Full 1280x720 resolution
           },
-          maxQuality: "medium",
+          maxQuality: "low", // Only send the low layer
         };
         break;
       case "1080p":
@@ -169,21 +164,11 @@ export default function App() {
         };
         screenVideoSendSettings = {
           low: {
-            maxBitrate: 500000, // 500 kbps
-            maxFramerate: 15,
-            scaleResolutionDownBy: 4, // 480x270
-          },
-          medium: {
-            maxBitrate: 1500000, // 1.5 Mbps
+            maxBitrate: 2500000, // 2.5 Mbps for 1080p
             maxFramerate: 30,
-            scaleResolutionDownBy: 2, // 960x540
+            scaleResolutionDownBy: 1, // Full 1920x1080 resolution
           },
-          high: {
-            maxBitrate: 3000000, // 3 Mbps
-            maxFramerate: 30,
-            scaleResolutionDownBy: 1, // 1920x1080
-          },
-          maxQuality: "high",
+          maxQuality: "low", // Only send the low layer
         };
         break;
       default:


### PR DESCRIPTION
# Screen Share Send Settings Demo

This PR adds a comprehensive demo for Daily.js screen share send settings, allowing developers to configure custom screen share quality and transmission parameters.

## 🚀 Features Added

### Quality Options
- **480p (854x480)** - Low Bandwidth: 600 kbps, 15 fps
- **720p (1280x720)** - Standard Quality: 1.2 Mbps, 30 fps  
- **1080p (1920x1080)** - High Quality: 2.5 Mbps, 30 fps
- **Default** - Motion Optimized: Daily's automatic settings

### Technical Implementation
- ✅ Single-layer simulcast architecture for optimal performance
- ✅ Custom `displayMediaOptions` with resolution constraints
- ✅ Configurable `screenVideoSendSettings` with bitrate control
- ✅ Real-time quality selection via UI dropdown
- ✅ Comprehensive logging for debugging and monitoring
- ✅ TypeScript type safety with proper error handling

## 📋 Changes Made

### Core Implementation (`src/App.tsx`)
- Added `startCustomScreenShare()` function with quality-specific configurations
- Implemented `screenShareQuality` state management
- Created quality selector dropdown UI component
- Added detailed console logging for each configuration mode
- Integrated with existing `useScreenShare` hook

### Quality Configurations
| Quality | Resolution | Bitrate | FPS | Use Case |
|---------|------------|---------|-----|----------|
| 480p | 854x480 | 600 kbps | 15 | Mobile/Low bandwidth |
| 720p | 1280x720 | 1.2 Mbps | 30 | Standard meetings |
| 1080p | 1920x1080 | 2.5 Mbps | 30 | High-quality presentations |
| Default | Auto | Auto | Auto | Motion-optimized |

## 🔧 Technical Details

### Single-Layer Architecture
Following Daily.js best practices, screen shares use single-layer transmission:
```javascript
screenVideoSendSettings = {
  low: {
    maxBitrate: 1200000,
    maxFramerate: 30,
    scaleResolutionDownBy: 1
  },
  maxQuality: "low" // Only send one layer
};