### PR TITLE
Add displayMediaOptions for screen share and startVideoOff

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -566,7 +566,15 @@ export default function App() {
             if (isSharingScreen) {
               stopScreenShare();
             } else {
-              startScreenShare();
+              startScreenShare({
+                displayMediaOptions: {
+                  video: true,
+                  audio: true,
+                  selfBrowserSurface: "exclude",
+                  surfaceSwitching: "include",
+                  systemAudio: "include",
+                },
+              });
             }
           }}
         >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ root.render(
     ) : (
       <DailyProvider
         subscribeToTracksAutomatically={false}
+        startVideoOff={true}
         dailyConfig={{ useDevicePreferenceCookies: true }}
       >
         <App />


### PR DESCRIPTION
## Summary
This PR enhances screen sharing functionality with display media options and improves the initial join experience.

## Changes

### Screen Share Enhancement
Added `displayMediaOptions` to the `startScreenShare()` call with the following options:
- `video: true` - Enable video capture
- `audio: true` - Enable audio capture  
- `selfBrowserSurface: "exclude"` - Prevents sharing the current browser tab (avoids infinite loop)
- `surfaceSwitching: "include"` - Allows users to switch which content they're sharing
- `systemAudio: "include"` - Enables system audio capture (where supported)

### Video Start Optimization
- Set `startVideoOff: true` in DailyProvider to prevent camera from auto-starting on join
- This improves performance and gives users more control over when to enable video

## Benefits
- Better UX: Users can switch between windows/tabs while sharing
- Prevents accidental self-sharing of the meeting tab
- System audio sharing available where browser supports it
- More efficient initial join (camera doesn't start automatically)

## Testing
- ✅ Screen share button works with new options
- ✅ Video starts off when joining a call
- ✅ No TypeScript or build errors