### PR TITLE
Disable audio processing on iOS Safari

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ const MicVolumeVisualizer = () => {
       // this volume number will be between 0 and 1
       // give it a minimum scale of 0.15 to not completely disappear 👻
       volRef.current.style.transform = `scale(${Math.max(0.15, volume)})`;
-    }, [])
+    }, []),
   );
 
   // Your audio track's audio volume visualized in a small circle,
@@ -70,10 +70,12 @@ export default function App() {
 
   const [enableBlurClicked, setEnableBlurClicked] = useState(false);
   const [enableBackgroundClicked, setEnableBackgroundClicked] = useState(false);
-  const [dailyRoomUrl, setDailyRoomUrl] = useState("");
+  const [dailyRoomUrl, setDailyRoomUrl] = useState(
+    "https://hush.daily.co/demo",
+  );
   const [dailyMeetingToken, setDailyMeetingToken] = useState("");
   const [trackSettings, setTrackSettings] = useState<MediaTrackSettings | null>(
-    null
+    null,
   );
 
   const {
@@ -145,7 +147,7 @@ export default function App() {
           },
         });
       },
-      [callObject, logEvent]
+      [callObject, logEvent],
     ),
     onParticipantLeft: logEvent,
     onParticipantUpdated: logEvent,
@@ -286,8 +288,8 @@ export default function App() {
         logEvent(ev);
         setIsRemoteMediaPlayerStarted(true);
       },
-      [logEvent, setIsRemoteMediaPlayerStarted]
-    )
+      [logEvent, setIsRemoteMediaPlayerStarted],
+    ),
   );
   useDailyEvent(
     "remote-media-player-started",
@@ -297,8 +299,8 @@ export default function App() {
         logEvent(ev);
         setIsRemoteMediaPlayerStarted(true);
       },
-      [logEvent, setIsRemoteMediaPlayerStarted]
-    )
+      [logEvent, setIsRemoteMediaPlayerStarted],
+    ),
   );
   useDailyEvent("remote-media-player-updated", logEvent);
 
@@ -428,7 +430,7 @@ export default function App() {
         console.error("Error setting camera", err);
       });
     },
-    [setCamera]
+    [setCamera],
   );
 
   // change mic device
@@ -438,7 +440,7 @@ export default function App() {
         console.error("Error setting microphone", err);
       });
     },
-    [setMicrophone]
+    [setMicrophone],
   );
 
   // change speaker device
@@ -448,7 +450,7 @@ export default function App() {
         console.error("Error setting speaker", err);
       });
     },
-    [setSpeaker]
+    [setSpeaker],
   );
 
   const stopCamera = useCallback(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,9 @@ export default function App() {
   const [enableBackgroundClicked, setEnableBackgroundClicked] = useState(false);
   const [dailyRoomUrl, setDailyRoomUrl] = useState("");
   const [dailyMeetingToken, setDailyMeetingToken] = useState("");
+  const [trackSettings, setTrackSettings] = useState<MediaTrackSettings | null>(
+    null
+  );
 
   const {
     cameraError,
@@ -253,6 +256,19 @@ export default function App() {
       console.error("Error enabling Krisp", err);
     });
   }, [callObject, noiseCancellationEnabled, updateInputSettings]);
+
+  const readTrackSettings = useCallback(() => {
+    if (!callObject) return;
+    const audioTrack =
+      callObject.participants()?.local?.tracks?.audio?.persistentTrack;
+    if (!audioTrack) {
+      console.log("No audio track available yet");
+      return;
+    }
+    const settings = audioTrack.getSettings();
+    setTrackSettings(settings);
+    console.log("Actual audio track settings:", settings);
+  }, [callObject]);
 
   const rmpParticipantIds = useParticipantIds({
     sort: "joined_at",
@@ -560,6 +576,94 @@ export default function App() {
           Toggle Krisp
         </button>
         <br />
+        <hr />
+        <b>Audio Processing Constraints (set in DailyProvider)</b>
+        <br />
+        <p>
+          echoCancellation, noiseSuppression, and autoGainControl are set to{" "}
+          <code>false</code> via <code>inputSettings</code>. Click below to
+          verify what the browser actually applied.
+        </p>
+        <button onClick={readTrackSettings}>Read Actual Track Settings</button>
+        {trackSettings && (
+          <table
+            style={{
+              margin: "10px auto",
+              borderCollapse: "collapse",
+              textAlign: "left",
+            }}
+          >
+            <thead>
+              <tr>
+                <th style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  Setting
+                </th>
+                <th style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  Requested
+                </th>
+                <th style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  Actual
+                </th>
+                <th style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  Match?
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  echoCancellation
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  false
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  {String(trackSettings.echoCancellation ?? "N/A")}
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  {trackSettings.echoCancellation === false ? "Yes" : "NO"}
+                </td>
+              </tr>
+              <tr>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  noiseSuppression
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  false
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  {String(trackSettings.noiseSuppression ?? "N/A")}
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  {trackSettings.noiseSuppression === false ? "Yes" : "NO"}
+                </td>
+              </tr>
+              <tr>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  autoGainControl
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  false
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  {String(trackSettings.autoGainControl ?? "N/A")}
+                </td>
+                <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  {trackSettings.autoGainControl === false ? "Yes" : "NO"}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+        {trackSettings && (
+          <details style={{ maxWidth: "600px", margin: "0 auto" }}>
+            <summary>Full track settings (JSON)</summary>
+            <pre style={{ textAlign: "left", overflow: "auto" }}>
+              {JSON.stringify(trackSettings, null, 2)}
+            </pre>
+          </details>
+        )}
+        <hr />
         <button
           disabled={isSharingScreen}
           onClick={() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,15 @@ root.render(
       <DailyProvider
         subscribeToTracksAutomatically={false}
         dailyConfig={{ useDevicePreferenceCookies: true }}
+        inputSettings={{
+          audio: {
+            settings: {
+              echoCancellation: false,
+              noiseSuppression: false,
+              autoGainControl: false,
+            },
+          },
+        }}
       >
         <App />
       </DailyProvider>


### PR DESCRIPTION
## Summary
- Adds `inputSettings` to `DailyProvider` in `src/index.tsx` to set `echoCancellation`, `noiseSuppression`, and `autoGainControl` to `false` — these constraints are passed verbatim to `getUserMedia()`
- Adds a verification UI in `src/App.tsx` with a "Read Actual Track Settings" button that calls `MediaStreamTrack.getSettings()` to check whether the browser honored the constraints
- Displays a comparison table (Requested vs Actual vs Match) and a collapsible full JSON dump of track settings

## How to test
1. `npm run dev` and join a Daily call
2. Click "Read Actual Track Settings" to see what the browser applied
3. Test on **iOS Safari** to verify which constraints it honors vs ignores
4. Compare results across Chrome, desktop Safari, and iOS Safari

## Background
Per [Daily docs](https://docs.daily.co/reference/daily-js/instance-methods/update-input-settings#audio-video-settings), `audio.settings` accepts `MediaTrackConstraints` passed as-is to `getUserMedia()`. However, the docs warn that "track constraints are implemented inconsistently across browsers." This demo exists to test that behavior on iOS Safari specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)