### PR TITLE
Add custom ICE server configuration demo

### DIFF
--- a/src/Prebuilt.tsx
+++ b/src/Prebuilt.tsx
@@ -85,6 +85,19 @@ export const Prebuilt = () => {
     options: {
       dailyConfig: {
         useDevicePreferenceCookies: true,
+        iceConfig: {
+          iceServers: [
+            {
+              urls: [
+                "stun:stun.l.google.com:19302",
+                "stun:stun1.l.google.com:19302",
+                "stun:stun.cloudflare.com:3478",
+              ],
+            },
+          ],
+          placement: "replace",
+          iceTransportPolicy: "all",
+        },
       },
       url: "https://hush.daily.co/demo",
       iframeStyle: {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,22 @@ root.render(
     ) : (
       <DailyProvider
         subscribeToTracksAutomatically={false}
-        dailyConfig={{ useDevicePreferenceCookies: true }}
+        dailyConfig={{
+          useDevicePreferenceCookies: true,
+          iceConfig: {
+            iceServers: [
+              {
+                urls: [
+                  "stun:stun.l.google.com:19302",
+                  "stun:stun1.l.google.com:19302",
+                  "stun:stun.cloudflare.com:3478",
+                ],
+              },
+            ],
+            placement: "replace",
+            iceTransportPolicy: "all",
+          },
+        }}
       >
         <App />
       </DailyProvider>


### PR DESCRIPTION
## Summary
- Configures custom STUN servers (Google + Cloudflare) in the `DailyProvider`'s `dailyConfig.iceConfig`
- Uses `placement: "replace"` to fully replace Daily's default ICE servers with custom ones
- Uses `iceTransportPolicy: "all"` to allow both direct and relay candidates

## Test plan
- [x] `npm test` passes (ESLint)
- [x] `npm run build` passes (TypeScript + Vite)
- [x] `npm run dev` — join a call and verify connectivity works with custom STUN servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)