### PR TITLE
Add eject and ban participant demo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@ const logEvent = useCallback((evt: DailyEventObject) => {
 - Don't use direct Daily event listeners when hooks are available
 - Avoid blocking UI operations during async Daily.js calls
 
+## Demo Branch Guidelines
+
+- **Additive changes only**: When creating demo branches, add new functionality on top of the existing code. Do not remove existing components, hooks, or UI sections — this keeps the git diff easy to read and review. Minimize style changes.
+
 ## Important Guidelines
 
 - Always upgrade to latest daily-js and daily-react versions before making changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "daily-react-kitchen-sink",
       "version": "0.0.0",
       "dependencies": {
-        "@daily-co/daily-js": "^0.83.1",
-        "@daily-co/daily-react": "^0.23.2",
+        "@daily-co/daily-js": "^0.89.1",
+        "@daily-co/daily-react": "^0.24.0",
         "@vitejs/plugin-react-swc": "^3.7.2",
         "html2canvas": "^1.4.1",
         "jotai": "^2.12.5",
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@daily-co/daily-js": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.83.1.tgz",
-      "integrity": "sha512-KXA3zrSnNPZONwhip4TI6ayD3huumI1QBD/xPAjFArvHuFFB7t0QTOS2oxH1bXvdOBJ6XnY08vdlJslTVi2/2w==",
+      "version": "0.89.1",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.89.1.tgz",
+      "integrity": "sha512-1RnXtzg8aeJYLhmMjRK9mnsWRljwsM2OUBJH5onpAOFIjHPSA7h03DSCd8D/YMyrpX8jQHcVMDSWOhcj+tZD/A==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@sentry/browser": "^8.33.1",
@@ -370,13 +370,13 @@
         "events": "^3.1.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=22.14.0"
       }
     },
     "node_modules/@daily-co/daily-react": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-react/-/daily-react-0.23.2.tgz",
-      "integrity": "sha512-LDmAfgEYTGoPJYZYBtWfMoXLl6MJJq1Rf4kukPW1NgFO443om99mHEcw33seV8PRXUl+JUmcpXnSmkX2pqEB9g==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-react/-/daily-react-0.24.0.tgz",
+      "integrity": "sha512-eJH/EGicqtXcb33mua2kpZfowXL+zos2/s2lRMkENNZYBjlPNP2fNYqxx5FkK9grGc1gLfOUgULvONDOmfeFbg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash.throttle": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "npm": ">=8.0.0"
   },
   "dependencies": {
-    "@daily-co/daily-js": "^0.83.1",
-    "@daily-co/daily-react": "^0.23.2",
+    "@daily-co/daily-js": "^0.89.1",
+    "@daily-co/daily-react": "^0.24.0",
     "@vitejs/plugin-react-swc": "^3.7.2",
     "html2canvas": "^1.4.1",
     "jotai": "^2.12.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ const MicVolumeVisualizer = () => {
       // this volume number will be between 0 and 1
       // give it a minimum scale of 0.15 to not completely disappear 👻
       volRef.current.style.transform = `scale(${Math.max(0.15, volume)})`;
-    }, [])
+    }, []),
   );
 
   // Your audio track's audio volume visualized in a small circle,
@@ -73,8 +73,8 @@ export default function App() {
   const [enableBlurClicked, setEnableBlurClicked] = useState(false);
   const [enableBackgroundClicked, setEnableBackgroundClicked] = useState(false);
   const [dailyRoomUrl, setDailyRoomUrl] = useState("");
-  const [dailyMeetingToken, setDailyMeetingToken] = useState((import.meta.env.VITE_DAILY_MEETING_TOKEN as string) ?? "");
-  const [dailyApiKey, setDailyApiKey] = useState((import.meta.env.VITE_DAILY_API_KEY as string) ?? "");
+  const [dailyMeetingToken, setDailyMeetingToken] = useState("");
+  const [dailyApiKey, setDailyApiKey] = useState("");
 
   const {
     cameraError,
@@ -145,7 +145,7 @@ export default function App() {
           },
         });
       },
-      [callObject, logEvent]
+      [callObject, logEvent],
     ),
     onParticipantLeft: logEvent,
     onParticipantUpdated: logEvent,
@@ -208,19 +208,28 @@ export default function App() {
       callObject.updateParticipant(sessionId, { eject: true });
       console.log(`Ejected participant: ${participantName} (${sessionId})`);
     },
-    [callObject]
+    [callObject],
   );
 
   // Ban a participant: eject them client-side, then call the REST API to
   // prevent them from rejoining. Requires a Daily API key.
   const banParticipant = useCallback(
     (sessionId: string, participantName: string) => {
-      console.log("banParticipant called", { sessionId, participantName, callObject: !!callObject, dailyRoomUrl, dailyApiKey: !!dailyApiKey });
+      console.log("banParticipant called", {
+        sessionId,
+        participantName,
+        callObject: !!callObject,
+        dailyRoomUrl,
+        dailyApiKey: !!dailyApiKey,
+      });
       if (!callObject) return;
 
       const participant = callObject.participants()?.[sessionId];
       const userId = participant?.user_id;
-      console.log("banParticipant participant lookup", { participant: !!participant, userId });
+      console.log("banParticipant participant lookup", {
+        participant: !!participant,
+        userId,
+      });
 
       const roomName = dailyRoomUrl.split("/").pop();
       if (!roomName) {
@@ -233,7 +242,7 @@ export default function App() {
         callObject.updateParticipant(sessionId, { eject: true });
         console.warn(
           "No API key provided — participant was ejected but not banned. " +
-            "Enter a Daily API key to enable banning."
+            "Enter a Daily API key to enable banning.",
         );
         return;
       }
@@ -241,7 +250,7 @@ export default function App() {
       if (!userId) {
         console.warn(
           "Participant has no user_id — ban won't prevent rejoining. " +
-            "Use meeting tokens with a user_id for effective banning."
+            "Use meeting tokens with a user_id for effective banning.",
         );
       }
 
@@ -272,31 +281,33 @@ export default function App() {
             });
           }
           return res.json().then((data) => {
-            console.log(`Banned participant: ${participantName} (${sessionId})`, data);
+            console.log(
+              `Banned participant: ${participantName} (${sessionId})`,
+              data,
+            );
           });
         })
         .catch((err) => {
           console.error("Error calling ban API:", err);
         });
     },
-    [callObject, dailyRoomUrl, dailyApiKey]
+    [callObject, dailyRoomUrl, dailyApiKey],
   );
 
   // Log participant-left events with reason to confirm ejections
   useDailyEvent(
     "participant-left",
-    useCallback(
-      (ev: DailyEventObjectParticipantLeft) => {
-        if (!ev) return;
-        const reason = (ev as DailyEventObjectParticipantLeft & { reason?: string }).reason;
-        if (reason) {
-          console.log(
-            `Participant left: ${ev.participant.user_name ?? ev.participant.session_id} — reason: ${reason}`
-          );
-        }
-      },
-      []
-    )
+    useCallback((ev: DailyEventObjectParticipantLeft) => {
+      if (!ev) return;
+      const reason = (
+        ev as DailyEventObjectParticipantLeft & { reason?: string }
+      ).reason;
+      if (reason) {
+        console.log(
+          `Participant left: ${ev.participant.user_name ?? ev.participant.session_id} — reason: ${reason}`,
+        );
+      }
+    }, []),
   );
 
   const enableBlur = useCallback(() => {
@@ -374,8 +385,8 @@ export default function App() {
         logEvent(ev);
         setIsRemoteMediaPlayerStarted(true);
       },
-      [logEvent, setIsRemoteMediaPlayerStarted]
-    )
+      [logEvent, setIsRemoteMediaPlayerStarted],
+    ),
   );
   useDailyEvent(
     "remote-media-player-started",
@@ -385,8 +396,8 @@ export default function App() {
         logEvent(ev);
         setIsRemoteMediaPlayerStarted(true);
       },
-      [logEvent, setIsRemoteMediaPlayerStarted]
-    )
+      [logEvent, setIsRemoteMediaPlayerStarted],
+    ),
   );
   useDailyEvent("remote-media-player-updated", logEvent);
 
@@ -516,7 +527,7 @@ export default function App() {
         console.error("Error setting camera", err);
       });
     },
-    [setCamera]
+    [setCamera],
   );
 
   // change mic device
@@ -526,7 +537,7 @@ export default function App() {
         console.error("Error setting microphone", err);
       });
     },
-    [setMicrophone]
+    [setMicrophone],
   );
 
   // change speaker device
@@ -536,7 +547,7 @@ export default function App() {
         console.error("Error setting speaker", err);
       });
     },
-    [setSpeaker]
+    [setSpeaker],
   );
 
   const stopCamera = useCallback(() => {
@@ -718,8 +729,7 @@ export default function App() {
                 className="eject-btn"
                 onClick={() => {
                   const participants = callObject?.participants();
-                  const name =
-                    participants?.[id]?.user_name ?? id;
+                  const name = participants?.[id]?.user_name ?? id;
                   ejectParticipant(id, name);
                 }}
               >
@@ -729,8 +739,7 @@ export default function App() {
                 className="eject-btn ban-btn"
                 onClick={() => {
                   const participants = callObject?.participants();
-                  const name =
-                    participants?.[id]?.user_name ?? id;
+                  const name = participants?.[id]?.user_name ?? id;
                   banParticipant(id, name);
                 }}
               >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,8 +73,8 @@ export default function App() {
   const [enableBlurClicked, setEnableBlurClicked] = useState(false);
   const [enableBackgroundClicked, setEnableBackgroundClicked] = useState(false);
   const [dailyRoomUrl, setDailyRoomUrl] = useState("");
-  const [dailyMeetingToken, setDailyMeetingToken] = useState("");
-  const [dailyApiKey, setDailyApiKey] = useState("");
+  const [dailyMeetingToken, setDailyMeetingToken] = useState((import.meta.env.VITE_DAILY_MEETING_TOKEN as string) ?? "");
+  const [dailyApiKey, setDailyApiKey] = useState((import.meta.env.VITE_DAILY_API_KEY as string) ?? "");
 
   const {
     cameraError,
@@ -215,13 +215,12 @@ export default function App() {
   // prevent them from rejoining. Requires a Daily API key.
   const banParticipant = useCallback(
     (sessionId: string, participantName: string) => {
+      console.log("banParticipant called", { sessionId, participantName, callObject: !!callObject, dailyRoomUrl, dailyApiKey: !!dailyApiKey });
       if (!callObject) return;
 
       const participant = callObject.participants()?.[sessionId];
       const userId = participant?.user_id;
-
-      callObject.updateParticipant(sessionId, { eject: true });
-      console.log(`Ejected participant: ${participantName} (${sessionId})`);
+      console.log("banParticipant participant lookup", { participant: !!participant, userId });
 
       const roomName = dailyRoomUrl.split("/").pop();
       if (!roomName) {
@@ -230,6 +229,8 @@ export default function App() {
       }
 
       if (!dailyApiKey) {
+        // No API key — fall back to client-side eject only
+        callObject.updateParticipant(sessionId, { eject: true });
         console.warn(
           "No API key provided — participant was ejected but not banned. " +
             "Enter a Daily API key to enable banning."
@@ -237,14 +238,24 @@ export default function App() {
         return;
       }
 
-      const body: { ids?: string[]; user_ids?: string[]; ban: boolean } = {
+      if (!userId) {
+        console.warn(
+          "Participant has no user_id — ban won't prevent rejoining. " +
+            "Use meeting tokens with a user_id for effective banning."
+        );
+      }
+
+      // Always use session ids to eject. Additionally include user_ids
+      // for the ban — banning only persists for user_ids set via meeting tokens.
+      const body: { ids: string[]; user_ids?: string[]; ban: boolean } = {
+        ids: [sessionId],
         ban: true,
       };
-      if (userId) {
+      if (userId && userId !== sessionId) {
         body.user_ids = [userId];
-      } else {
-        body.ids = [sessionId];
       }
+
+      console.log("banParticipant REST API request", { roomName, body });
 
       fetch(`https://api.daily.co/v1/rooms/${roomName}/eject`, {
         method: "POST",
@@ -260,7 +271,9 @@ export default function App() {
               console.error("Ban API error:", err);
             });
           }
-          console.log(`Banned participant: ${participantName} (${sessionId})`);
+          return res.json().then((data) => {
+            console.log(`Banned participant: ${participantName} (${sessionId})`, data);
+          });
         })
         .catch((err) => {
           console.error("Error calling ban API:", err);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef, useState } from "react";
 import Daily, {
   DailyEventObject,
   DailyEventObjectParticipant,
+  DailyEventObjectParticipantLeft,
 } from "@daily-co/daily-js";
 
 import {
@@ -19,6 +20,7 @@ import {
   useNetwork,
   useParticipantCounts,
   useParticipantIds,
+  usePermissions,
   useRecording,
   useScreenShare,
   useTranscription,
@@ -72,6 +74,7 @@ export default function App() {
   const [enableBackgroundClicked, setEnableBackgroundClicked] = useState(false);
   const [dailyRoomUrl, setDailyRoomUrl] = useState("");
   const [dailyMeetingToken, setDailyMeetingToken] = useState("");
+  const [dailyApiKey, setDailyApiKey] = useState("");
 
   const {
     cameraError,
@@ -194,6 +197,94 @@ export default function App() {
   if (nonFatalError) {
     logEvent(nonFatalError);
   }
+
+  // --- Eject / Ban Participant ---
+  const localSessionId = useLocalSessionId();
+  const { canAdminParticipants } = usePermissions();
+
+  const ejectParticipant = useCallback(
+    (sessionId: string, participantName: string) => {
+      if (!callObject) return;
+      callObject.updateParticipant(sessionId, { eject: true });
+      console.log(`Ejected participant: ${participantName} (${sessionId})`);
+    },
+    [callObject]
+  );
+
+  // Ban a participant: eject them client-side, then call the REST API to
+  // prevent them from rejoining. Requires a Daily API key.
+  const banParticipant = useCallback(
+    (sessionId: string, participantName: string) => {
+      if (!callObject) return;
+
+      const participant = callObject.participants()?.[sessionId];
+      const userId = participant?.user_id;
+
+      callObject.updateParticipant(sessionId, { eject: true });
+      console.log(`Ejected participant: ${participantName} (${sessionId})`);
+
+      const roomName = dailyRoomUrl.split("/").pop();
+      if (!roomName) {
+        console.error("Could not extract room name from URL:", dailyRoomUrl);
+        return;
+      }
+
+      if (!dailyApiKey) {
+        console.warn(
+          "No API key provided — participant was ejected but not banned. " +
+            "Enter a Daily API key to enable banning."
+        );
+        return;
+      }
+
+      const body: { ids?: string[]; user_ids?: string[]; ban: boolean } = {
+        ban: true,
+      };
+      if (userId) {
+        body.user_ids = [userId];
+      } else {
+        body.ids = [sessionId];
+      }
+
+      fetch(`https://api.daily.co/v1/rooms/${roomName}/eject`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${dailyApiKey}`,
+        },
+        body: JSON.stringify(body),
+      })
+        .then((res) => {
+          if (!res.ok) {
+            return res.json().then((err) => {
+              console.error("Ban API error:", err);
+            });
+          }
+          console.log(`Banned participant: ${participantName} (${sessionId})`);
+        })
+        .catch((err) => {
+          console.error("Error calling ban API:", err);
+        });
+    },
+    [callObject, dailyRoomUrl, dailyApiKey]
+  );
+
+  // Log participant-left events with reason to confirm ejections
+  useDailyEvent(
+    "participant-left",
+    useCallback(
+      (ev: DailyEventObjectParticipantLeft) => {
+        if (!ev) return;
+        const reason = (ev as DailyEventObjectParticipantLeft & { reason?: string }).reason;
+        if (reason) {
+          console.log(
+            `Participant left: ${ev.participant.user_name ?? ev.participant.session_id} — reason: ${reason}`
+          );
+        }
+      },
+      []
+    )
+  );
 
   const enableBlur = useCallback(() => {
     if (!callObject || enableBlurClicked) {
@@ -485,6 +576,17 @@ export default function App() {
           }}
         />
         <br />
+        3. Daily API key (optional, required for banning participants).
+        <br />
+        <input
+          type="password"
+          value={dailyApiKey}
+          placeholder="Daily API key"
+          onChange={(event) => {
+            setDailyApiKey(event.target.value);
+          }}
+        />
+        <br />
         <button onClick={load}>Load</button> <br />
         <button disabled={!dailyRoomUrl.length} onClick={preAuth}>
           Preauth
@@ -595,7 +697,35 @@ export default function App() {
         </button>
       </div>
       {participantIds.map((id) => (
-        <DailyVideo type="video" key={id} automirror sessionId={id} />
+        <div key={id} className="participant-tile">
+          <DailyVideo type="video" automirror sessionId={id} />
+          {canAdminParticipants && id !== localSessionId && (
+            <>
+              <button
+                className="eject-btn"
+                onClick={() => {
+                  const participants = callObject?.participants();
+                  const name =
+                    participants?.[id]?.user_name ?? id;
+                  ejectParticipant(id, name);
+                }}
+              >
+                Eject
+              </button>
+              <button
+                className="eject-btn ban-btn"
+                onClick={() => {
+                  const participants = callObject?.participants();
+                  const name =
+                    participants?.[id]?.user_name ?? id;
+                  banParticipant(id, name);
+                }}
+              >
+                Ban
+              </button>
+            </>
+          )}
+        </div>
       ))}
       {screens.map((screen) => (
         <DailyVideo

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
   useNetwork,
   useParticipantCounts,
   useParticipantIds,
+  useParticipantProperty,
   usePermissions,
   useRecording,
   useScreenShare,
@@ -31,6 +32,46 @@ import "./styles.css";
 console.info("Daily version: %s", Daily.version());
 console.info("Daily supported Browser:");
 console.dir(Daily.supportedBrowser());
+
+const ParticipantTile = ({
+  id,
+  localSessionId,
+  canAdminParticipants,
+  onEject,
+  onBan,
+}: {
+  id: string;
+  localSessionId: string;
+  canAdminParticipants: boolean;
+  onEject: (sessionId: string, name: string) => void;
+  onBan: (sessionId: string, name: string, userId?: string) => void;
+}) => {
+  const userName = useParticipantProperty(id, "user_name");
+  const userId = useParticipantProperty(id, "user_id");
+  const displayName = userName ?? id;
+
+  return (
+    <div className="participant-tile">
+      <DailyVideo type="video" automirror sessionId={id} />
+      {canAdminParticipants && id !== localSessionId && (
+        <>
+          <button
+            className="eject-btn"
+            onClick={() => onEject(id, displayName)}
+          >
+            Eject
+          </button>
+          <button
+            className="eject-btn ban-btn"
+            onClick={() => onBan(id, displayName, userId)}
+          >
+            Ban
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
 
 const MicVolumeVisualizer = () => {
   const localSessionId = useLocalSessionId();
@@ -214,7 +255,7 @@ export default function App() {
   // Ban a participant: eject them client-side, then call the REST API to
   // prevent them from rejoining. Requires a Daily API key.
   const banParticipant = useCallback(
-    (sessionId: string, participantName: string) => {
+    (sessionId: string, participantName: string, userId?: string) => {
       console.log("banParticipant called", {
         sessionId,
         participantName,
@@ -223,13 +264,6 @@ export default function App() {
         dailyApiKey: !!dailyApiKey,
       });
       if (!callObject) return;
-
-      const participant = callObject.participants()?.[sessionId];
-      const userId = participant?.user_id;
-      console.log("banParticipant participant lookup", {
-        participant: !!participant,
-        userId,
-      });
 
       const roomName = dailyRoomUrl.split("/").pop();
       if (!roomName) {
@@ -721,33 +755,14 @@ export default function App() {
         </button>
       </div>
       {participantIds.map((id) => (
-        <div key={id} className="participant-tile">
-          <DailyVideo type="video" automirror sessionId={id} />
-          {canAdminParticipants && id !== localSessionId && (
-            <>
-              <button
-                className="eject-btn"
-                onClick={() => {
-                  const participants = callObject?.participants();
-                  const name = participants?.[id]?.user_name ?? id;
-                  ejectParticipant(id, name);
-                }}
-              >
-                Eject
-              </button>
-              <button
-                className="eject-btn ban-btn"
-                onClick={() => {
-                  const participants = callObject?.participants();
-                  const name = participants?.[id]?.user_name ?? id;
-                  banParticipant(id, name);
-                }}
-              >
-                Ban
-              </button>
-            </>
-          )}
-        </div>
+        <ParticipantTile
+          key={id}
+          id={id}
+          localSessionId={localSessionId}
+          canAdminParticipants={canAdminParticipants}
+          onEject={ejectParticipant}
+          onBan={banParticipant}
+        />
       ))}
       {screens.map((screen) => (
         <DailyVideo

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,3 +8,25 @@
   grid-template-rows: 1fr 10fr;
   grid-gap: 20px;
 }
+
+.participant-tile {
+  position: relative;
+  display: inline-block;
+}
+
+.eject-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: #e53e3e;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.eject-btn:hover {
+  background: #c53030;
+}


### PR DESCRIPTION
## Summary
- Adds eject and ban buttons on each remote participant's video tile (visible to meeting owners)
- Eject removes the participant from the call using `updateParticipant({ eject: true })`
- Ban ejects and then calls the Daily REST API `/rooms/{room}/eject` to prevent rejoining (requires an API key)
- Upgrades `daily-js` to 0.89.1 and `daily-react` to 0.24.0
- Adds demo branch guidelines to CLAUDE.md

## Test plan
- [x] Join a call as an owner — verify Eject/Ban buttons appear on remote participants
- [x] Join as a non-owner — verify buttons are hidden
- [x] Click Eject — verify remote participant is removed
- [x] Enter a Daily API key and click Ban — verify participant is ejected and banned via REST API
- [x] Omit API key and click Ban — verify participant is ejected with a console warning about banning

🤖 Generated with [Claude Code](https://claude.com/claude-code)