### PR TITLE
Daily Prebuilt closed captions demo

### DIFF
--- a/src/Prebuilt.tsx
+++ b/src/Prebuilt.tsx
@@ -4,15 +4,10 @@ import {
   DailyProvider,
   useCallFrame,
   useDaily,
-  useDailyEvent,
   useParticipantCounts,
   useParticipantIds,
-  useTranscription,
 } from "@daily-co/daily-react";
-import {
-  DailyEventObject,
-  DailyEventObjectCustomButtonClick,
-} from "@daily-co/daily-js";
+import { DailyEventObject } from "@daily-co/daily-js";
 
 const App = () => {
   const callObject = useDaily();
@@ -37,93 +32,7 @@ const App = () => {
     onParticipantUpdated: logEvent,
   });
 
-  const { startTranscription, stopTranscription, isTranscribing, transcriptions } =
-    useTranscription({
-      onTranscriptionStarted: logEvent,
-      onTranscriptionStopped: logEvent,
-      onTranscriptionError: logEvent,
-      onTranscriptionMessage: logEvent,
-    });
-
-  useDailyEvent(
-    "custom-button-click",
-    useCallback(
-      (evt: DailyEventObjectCustomButtonClick) => {
-        if (evt.button_id === "transcription") {
-          if (isTranscribing) {
-            stopTranscription();
-          } else {
-            startTranscription({
-              language: "multi",
-              model: "nova-2-general",
-              profanity_filter: true,
-              punctuate: true,
-              includeRawResponse: true,
-              extra: {
-                interim_results: true,
-              },
-            });
-          }
-        }
-      },
-      [isTranscribing, startTranscription, stopTranscription]
-    )
-  );
-
-  const panelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (panelRef.current) {
-      panelRef.current.scrollTop = panelRef.current.scrollHeight;
-    }
-  }, [transcriptions]);
-
-  return (
-    <>
-      <div
-        ref={panelRef}
-        style={{
-          maxHeight: 300,
-          overflowY: "auto",
-          border: "1px solid #e0e0e0",
-          borderRadius: 8,
-          margin: 16,
-          padding: 16,
-          background: "#fafafa",
-          fontFamily: "sans-serif",
-        }}
-      >
-        <h3 style={{ margin: "0 0 12px 0", fontSize: 16, color: "#333" }}>
-          Multi-Language Transcription {isTranscribing ? "(Active)" : "(Inactive)"}
-        </h3>
-        {transcriptions.length === 0 && (
-          <p style={{ color: "#888", fontStyle: "italic", fontSize: 14 }}>
-            {isTranscribing
-              ? "Listening for speech..."
-              : "Click the Transcribe button in the call tray to start."}
-          </p>
-        )}
-        {transcriptions.map((t, index) => (
-          <div
-            key={`${t.session_id}-${t.timestamp}-${index}`}
-            style={{
-              marginBottom: 8,
-              paddingBottom: 4,
-              borderBottom: "1px solid #f0f0f0",
-              fontSize: 14,
-              lineHeight: 1.4,
-            }}
-          >
-            <span style={{ fontWeight: 600, color: "#1a73e8" }}>
-              {t.user_name ?? t.user_id}:
-            </span>{" "}
-            <span style={{ color: "#333" }}>{t.text}</span>
-          </div>
-        ))}
-      </div>
-      <span>{participantCount.present} participants</span>
-    </>
-  );
+  return <span>{participantCount.present} participants</span>;
 };
 
 export const Prebuilt = () => {
@@ -137,23 +46,13 @@ export const Prebuilt = () => {
       },
       url: "https://hush.daily.co/demo",
       token:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvIjp0cnVlLCJyIjoiZGVtbyIsImQiOiI2ODNiODlmNC1iMWZkLTRmOTQtYjg0NS1lZjI2NjZlM2UyMTMiLCJpYXQiOjE3NzE4MTgwMjV9.NgoqiZV3vumDX1RFFjqW1UiaXqqdPoky3_MzLIC-GoU",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiZGVtbyIsIm8iOnRydWUsImFzdCI6dHJ1ZSwiZWxjIjp0cnVlLCJkIjoiNjgzYjg5ZjQtYjFmZC00Zjk0LWI4NDUtZWYyNjY2ZTNlMjEzIiwiaWF0IjoxNzcxODE4NDk2fQ.Ow2NL4lXVH5qbzgzbgBHaoMRqUlSBRzRtrCjnVI8SQA",
       iframeStyle: {
         width: "100%",
         height: "80vh",
       },
       userData: {
         avatar: "https://www.svgrepo.com/show/532036/cloud-rain-alt.svg",
-      },
-      customTrayButtons: {
-        transcription: {
-          iconPath:
-            "https://cdn.jsdelivr.net/npm/heroicons@2.1.1/24/outline/chat-bubble-bottom-center-text.svg",
-          iconPathDarkMode:
-            "https://cdn.jsdelivr.net/npm/heroicons@2.1.1/24/outline/chat-bubble-bottom-center-text.svg",
-          label: "Transcribe",
-          tooltip: "Toggle multi-language transcription",
-        },
       },
     },
     shouldCreateInstance: useCallback(() => Boolean(wrapperRef.current), []),

--- a/src/Prebuilt.tsx
+++ b/src/Prebuilt.tsx
@@ -2,15 +2,16 @@ import "./styles.css";
 import { useCallback, useEffect, useRef } from "react";
 import {
   DailyProvider,
-  useAppMessage,
   useCallFrame,
   useDaily,
+  useDailyEvent,
   useParticipantCounts,
   useParticipantIds,
+  useTranscription,
 } from "@daily-co/daily-react";
 import {
   DailyEventObject,
-  DailyEventObjectAppMessage,
+  DailyEventObjectCustomButtonClick,
 } from "@daily-co/daily-js";
 
 const App = () => {
@@ -36,42 +37,90 @@ const App = () => {
     onParticipantUpdated: logEvent,
   });
 
-  type PrebuiltAppMessage = DailyEventObjectAppMessage<{
-    date: string;
-    event: "chat-msg"; // There's other events too
-    message: string;
-    name: string;
-    room: string;
-  }>;
+  const { startTranscription, stopTranscription, isTranscribing, transcriptions } =
+    useTranscription({
+      onTranscriptionStarted: logEvent,
+      onTranscriptionStopped: logEvent,
+      onTranscriptionError: logEvent,
+      onTranscriptionMessage: logEvent,
+    });
 
-  const sendAppMessage = useAppMessage({
-    onAppMessage: useCallback((message: PrebuiltAppMessage) => {
-      console.log(message);
-      switch (message.data.event) {
-        case "chat-msg":
-          console.log("Chat message:", message.data.message);
-          break;
-        default:
-          console.log("Unknown event:", message.data.event);
-      }
-    }, []),
-  });
+  useDailyEvent(
+    "custom-button-click",
+    useCallback(
+      (evt: DailyEventObjectCustomButtonClick) => {
+        if (evt.button_id === "transcription") {
+          if (isTranscribing) {
+            stopTranscription();
+          } else {
+            startTranscription({
+              language: "multi",
+              model: "nova-2-general",
+              profanity_filter: true,
+              punctuate: true,
+              includeRawResponse: true,
+              extra: {
+                interim_results: true,
+              },
+            });
+          }
+        }
+      },
+      [isTranscribing, startTranscription, stopTranscription]
+    )
+  );
+
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (panelRef.current) {
+      panelRef.current.scrollTop = panelRef.current.scrollHeight;
+    }
+  }, [transcriptions]);
 
   return (
     <>
-      <button
-        onClick={() =>
-          sendAppMessage({
-            event: "chat-msg",
-            date: Date.now().toString(),
-            message: "Hello from button!",
-            name: "button",
-            room: "main-room",
-          })
-        }
+      <div
+        ref={panelRef}
+        style={{
+          maxHeight: 300,
+          overflowY: "auto",
+          border: "1px solid #e0e0e0",
+          borderRadius: 8,
+          margin: 16,
+          padding: 16,
+          background: "#fafafa",
+          fontFamily: "sans-serif",
+        }}
       >
-        Send message
-      </button>
+        <h3 style={{ margin: "0 0 12px 0", fontSize: 16, color: "#333" }}>
+          Multi-Language Transcription {isTranscribing ? "(Active)" : "(Inactive)"}
+        </h3>
+        {transcriptions.length === 0 && (
+          <p style={{ color: "#888", fontStyle: "italic", fontSize: 14 }}>
+            {isTranscribing
+              ? "Listening for speech..."
+              : "Click the Transcribe button in the call tray to start."}
+          </p>
+        )}
+        {transcriptions.map((t, index) => (
+          <div
+            key={`${t.session_id}-${t.timestamp}-${index}`}
+            style={{
+              marginBottom: 8,
+              paddingBottom: 4,
+              borderBottom: "1px solid #f0f0f0",
+              fontSize: 14,
+              lineHeight: 1.4,
+            }}
+          >
+            <span style={{ fontWeight: 600, color: "#1a73e8" }}>
+              {t.user_name ?? t.user_id}:
+            </span>{" "}
+            <span style={{ color: "#333" }}>{t.text}</span>
+          </div>
+        ))}
+      </div>
       <span>{participantCount.present} participants</span>
     </>
   );
@@ -93,6 +142,15 @@ export const Prebuilt = () => {
       },
       userData: {
         avatar: "https://www.svgrepo.com/show/532036/cloud-rain-alt.svg",
+      },
+      customTrayButtons: {
+        transcription: {
+          iconPath: "https://www.svgrepo.com/show/529657/chat-round-dots.svg",
+          iconPathDarkMode:
+            "https://www.svgrepo.com/show/529657/chat-round-dots.svg",
+          label: "Transcribe",
+          tooltip: "Toggle multi-language transcription",
+        },
       },
     },
     shouldCreateInstance: useCallback(() => Boolean(wrapperRef.current), []),

--- a/src/Prebuilt.tsx
+++ b/src/Prebuilt.tsx
@@ -46,7 +46,7 @@ export const Prebuilt = () => {
       },
       url: "https://hush.daily.co/demo",
       token:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiZGVtbyIsIm8iOnRydWUsImFzdCI6dHJ1ZSwiZWxjIjp0cnVlLCJkIjoiNjgzYjg5ZjQtYjFmZC00Zjk0LWI4NDUtZWYyNjY2ZTNlMjEzIiwiaWF0IjoxNzcxODE4NDk2fQ.Ow2NL4lXVH5qbzgzbgBHaoMRqUlSBRzRtrCjnVI8SQA",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiZGVtbyIsIm8iOnRydWUsImVsYyI6dHJ1ZSwicCI6eyJjYSI6InQifSwiZCI6IjY4M2I4OWY0LWIxZmQtNGY5NC1iODQ1LWVmMjY2NmUzZTIxMyIsImlhdCI6MTc3NDU5NjczNH0.klbT6tT0LqdbEY0Fi8Hq1jbGfHB2O_-qstnEQLB6gRg",
       iframeStyle: {
         width: "100%",
         height: "80vh",

--- a/src/Prebuilt.tsx
+++ b/src/Prebuilt.tsx
@@ -44,9 +44,9 @@ export const Prebuilt = () => {
       dailyConfig: {
         useDevicePreferenceCookies: true,
       },
-      url: "https://hush.daily.co/demo",
+      url: "https://hush.daily.co/closed-captions-demo",
       token:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiZGVtbyIsIm8iOnRydWUsImVsYyI6dHJ1ZSwicCI6eyJjYSI6InQifSwiZCI6IjY4M2I4OWY0LWIxZmQtNGY5NC1iODQ1LWVmMjY2NmUzZTIxMyIsImlhdCI6MTc3NDU5NzUyOH0.RA5QVKYjjz1Tk970I7L_3YHUMcN89TfIipvAgEUHPOU",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiY2xvc2VkLWNhcHRpb25zLWRlbW8iLCJvIjp0cnVlLCJlbGMiOnRydWUsInAiOnsiY2EiOiJ0In0sImQiOiI2ODNiODlmNC1iMWZkLTRmOTQtYjg0NS1lZjI2NjZlM2UyMTMiLCJpYXQiOjE3NzQ1OTc3OTZ9.0rxVdbS0twOlKk4vVGu-wQcViTp6nJYbthGIX4ylUvI",
       iframeStyle: {
         width: "100%",
         height: "80vh",

--- a/src/Prebuilt.tsx
+++ b/src/Prebuilt.tsx
@@ -136,6 +136,8 @@ export const Prebuilt = () => {
         useDevicePreferenceCookies: true,
       },
       url: "https://hush.daily.co/demo",
+      token:
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvIjp0cnVlLCJyIjoiZGVtbyIsImQiOiI2ODNiODlmNC1iMWZkLTRmOTQtYjg0NS1lZjI2NjZlM2UyMTMiLCJpYXQiOjE3NzE4MTgwMjV9.NgoqiZV3vumDX1RFFjqW1UiaXqqdPoky3_MzLIC-GoU",
       iframeStyle: {
         width: "100%",
         height: "80vh",
@@ -145,9 +147,10 @@ export const Prebuilt = () => {
       },
       customTrayButtons: {
         transcription: {
-          iconPath: "https://www.svgrepo.com/show/529657/chat-round-dots.svg",
+          iconPath:
+            "https://cdn.jsdelivr.net/npm/heroicons@2.1.1/24/outline/chat-bubble-bottom-center-text.svg",
           iconPathDarkMode:
-            "https://www.svgrepo.com/show/529657/chat-round-dots.svg",
+            "https://cdn.jsdelivr.net/npm/heroicons@2.1.1/24/outline/chat-bubble-bottom-center-text.svg",
           label: "Transcribe",
           tooltip: "Toggle multi-language transcription",
         },

--- a/src/Prebuilt.tsx
+++ b/src/Prebuilt.tsx
@@ -46,7 +46,7 @@ export const Prebuilt = () => {
       },
       url: "https://hush.daily.co/demo",
       token:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiZGVtbyIsIm8iOnRydWUsImVsYyI6dHJ1ZSwicCI6eyJjYSI6InQifSwiZCI6IjY4M2I4OWY0LWIxZmQtNGY5NC1iODQ1LWVmMjY2NmUzZTIxMyIsImlhdCI6MTc3NDU5NjczNH0.klbT6tT0LqdbEY0Fi8Hq1jbGfHB2O_-qstnEQLB6gRg",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiZGVtbyIsIm8iOnRydWUsImVsYyI6dHJ1ZSwicCI6eyJjYSI6InQifSwiZCI6IjY4M2I4OWY0LWIxZmQtNGY5NC1iODQ1LWVmMjY2NmUzZTIxMyIsImlhdCI6MTc3NDU5NzUyOH0.RA5QVKYjjz1Tk970I7L_3YHUMcN89TfIipvAgEUHPOU",
       iframeStyle: {
         width: "100%",
         height: "80vh",

--- a/src/Prebuilt.tsx
+++ b/src/Prebuilt.tsx
@@ -46,7 +46,7 @@ export const Prebuilt = () => {
       },
       url: "https://hush.daily.co/closed-captions-demo",
       token:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiY2xvc2VkLWNhcHRpb25zLWRlbW8iLCJvIjp0cnVlLCJlbGMiOnRydWUsInAiOnsiY2EiOiJ0In0sImQiOiI2ODNiODlmNC1iMWZkLTRmOTQtYjg0NS1lZjI2NjZlM2UyMTMiLCJpYXQiOjE3NzQ1OTc3OTZ9.0rxVdbS0twOlKk4vVGu-wQcViTp6nJYbthGIX4ylUvI",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyIjoiY2xvc2VkLWNhcHRpb25zLWRlbW8iLCJvIjp0cnVlLCJlbGMiOnRydWUsImFzdCI6ZmFsc2UsInAiOnsiY2EiOiJ0In0sImQiOiI2ODNiODlmNC1iMWZkLTRmOTQtYjg0NS1lZjI2NjZlM2UyMTMiLCJpYXQiOjE3NzQ2MDA3NjZ9.P-Mc5gwQgqKnYTXD1R-RdRfxAh8F6A7ZJF5GJaX0xKA",
       iframeStyle: {
         width: "100%",
         height: "80vh",


### PR DESCRIPTION
## Summary

This demo shows how to enable on-demand closed captions in Daily Prebuilt so participants can click the CC button to start transcription themselves — no auto-start needed.

The key configuration is in the meeting token:
- `enable_live_captions_ui: true` — shows the CC button in Prebuilt's tray
- `permissions: { canAdmin: ["transcription"] }` — allows the participant to start transcription when they click CC
- No `auto_start_transcription` — transcription only starts when a user clicks the CC button

## Setup: cURL commands

### 1. Create a meeting token with CC permissions

Generate a token that shows the CC button and grants permission to start transcription on demand:

```bash
curl -X POST "https://api.daily.co/v1/meeting-tokens" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer \$DAILY_API_KEY" \
  -d '{
    "properties": {
      "room_name": "YOUR_ROOM",
      "is_owner": true,
      "enable_live_captions_ui": true,
      "permissions": {
        "canAdmin": ["transcription"]
      }
    }
  }'
```

### 2. Use the token when joining

Pass the token from step 1 to the Daily Prebuilt \`useCallFrame\` options. When a participant clicks the CC button, transcription starts and captions appear in the call.

### Key difference from auto-start approach

| Approach | Token properties | Behavior |
|---|---|---|
| Auto-start (PR #103) | \`auto_start_transcription: true\` | Transcription starts when owner joins |
| **On-demand (this PR)** | \`permissions: { canAdmin: ["transcription"] }\` | **Transcription starts when user clicks CC button** |

Both approaches require \`enable_live_captions_ui: true\` to show the CC button.

## Test plan
- [ ] \`npm run dev\` and open \`localhost:3000?prebuilt=true\`
- [ ] Verify the CC button appears in Prebuilt's tray
- [ ] Click the CC button — verify "Captions will appear here" shows, then captions appear as participants speak
- [ ] Verify transcription does NOT auto-start on join (no \`transcription-started\` event until CC is clicked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)