### PR TITLE
Demo: VCS dominant-speaker recording

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import Daily, {
   DailyEventObject,
   DailyEventObjectParticipant,
@@ -7,6 +7,7 @@ import Daily, {
 import {
   DailyAudio,
   DailyVideo,
+  useActiveSpeakerId,
   useAudioLevelObserver,
   useCPULoad,
   useDaily,
@@ -166,12 +167,42 @@ export default function App() {
     onCPULoadChange: logEvent,
   });
 
-  const { startRecording, stopRecording, isRecording } = useRecording({
-    onRecordingData: logEvent,
-    onRecordingError: logEvent,
-    onRecordingStarted: logEvent,
-    onRecordingStopped: logEvent,
-  });
+  const { startRecording, stopRecording, updateRecording, isRecording } =
+    useRecording({
+      onRecordingData: logEvent,
+      onRecordingError: logEvent,
+      onRecordingStarted: logEvent,
+      onRecordingStopped: logEvent,
+    });
+
+  const activeSpeakerId = useActiveSpeakerId();
+  const preferredIdsRef = useRef<string[]>([]);
+
+  const buildDominantLayout = useCallback(
+    () => ({
+      preset: "custom" as const,
+      composition_params: {
+        mode: "dominant",
+        "videoSettings.preferScreenshare": true,
+        "videoSettings.dominant.followDomFlag": false,
+        "videoSettings.preferredParticipantIds":
+          preferredIdsRef.current.join(","),
+        "videoSettings.showParticipantLabels": true,
+      },
+    }),
+    []
+  );
+
+  useEffect(() => {
+    if (!activeSpeakerId) return;
+    preferredIdsRef.current = [
+      activeSpeakerId,
+      ...preferredIdsRef.current.filter((id) => id !== activeSpeakerId),
+    ].slice(0, 4);
+    if (isRecording) {
+      updateRecording({ layout: buildDominantLayout() });
+    }
+  }, [activeSpeakerId, isRecording, updateRecording, buildDominantLayout]);
 
   useDailyEvent("load-attempt-failed", logEvent);
   useDailyEvent("joining-meeting", logEvent);
@@ -575,7 +606,10 @@ export default function App() {
         <br />
         <button onClick={stopCamera}>Camera Off</button>
         <button onClick={updateCameraOn}>Camera On</button> <br />
-        <button disabled={isRecording} onClick={() => startRecording()}>
+        <button
+          disabled={isRecording}
+          onClick={() => startRecording({ layout: buildDominantLayout() })}
+        >
           Start Recording
         </button>
         <button disabled={!isRecording} onClick={() => stopRecording()}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -188,6 +188,11 @@ export default function App() {
         "videoSettings.preferredParticipantIds":
           preferredIdsRef.current.join(","),
         "videoSettings.showParticipantLabels": true,
+        "videoSettings.grid.labelPlacement": "inside-at-bottom",
+        "videoSettings.labels.color": "white",
+        "videoSettings.labels.strokeColor": "rgba(0, 0, 0, 1)",
+        "videoSettings.labels.fontWeight": "800",
+        "videoSettings.labels.offset_x_gu": 0.5,
       },
     }),
     []


### PR DESCRIPTION
## Summary

This is a **demo branch**, not intended to merge to `main`. It shows how to drive a VCS dominant-mode recording layout from the active speaker.

- Uses `useActiveSpeakerId` to track the current speaker.
- Maintains a rolling list of the 4 most-recent speakers in a ref (no re-renders needed since nothing in the UI reads from it).
- Passes the list as `videoSettings.preferredParticipantIds` in a `custom` preset with `mode: "dominant"`.
- Applies the layout on `startRecording` and refreshes it via `updateRecording` on every active-speaker change while a recording is in progress.

## Test plan

- [x] Join with 2+ participants, start recording, confirm the dominant tile follows whoever is speaking.
- [x] Verify the recorded MP4 reflects the same ordering (not just the live UI).
- [x] Confirm `preferredParticipantIds` updates in the Daily dashboard logs as speakers change.
- [x] Screen-share during the call and confirm `preferScreenshare: true` takes over.