### PR TITLE
Demo: line up raw-tracks audio into aligned per-speaker WAVs

### DIFF
--- a/raw-tracks-align/README.md
+++ b/raw-tracks-align/README.md
@@ -1,0 +1,122 @@
+# Line up raw-tracks audio (1/1 call)
+
+Daily raw-tracks gives you one audio file per participant, but the files can start at
+different points (a late joiner) and a participant can have more than one file (a
+reconnect splits their track). This demo turns those files into **one equal-length,
+front-aligned WAV per speaker**, lined up on a shared timeline.
+
+The whole thing is cheap because you let Daily do the hard part during the recording:
+
+1. **Record gapless WAV.** Set `enable_raw_tracks_transcoded_audio: wav-48k-mono` so each
+   file is already continuous: no internal mute or packet-loss holes to patch.
+2. **Get the offsets.** Set `enable_raw_tracks_event_json: true` so the recording also
+   writes an event JSON with each file's start offset on the session timeline. That
+   offset is the entire trick.
+3. **Align.** For each speaker, `adelay` each file to its offset, overlay the fragments
+   onto one timeline, then `apad` to a shared length. On 16-bit PCM this is near-instant:
+   no decode, no re-encode.
+
+Docs:
+- Gapless transcoded audio: https://docs.daily.co/docs/guides/features/recording/index#gapless-transcoded-audio
+- `enable_raw_tracks_event_json` (Apr 29 2026 changelog): https://docs.daily.co/changelog/077-2026-04-29#media-services
+
+## Why not the raw-tracks-tools CLI?
+
+The CLI aligns tracks too, but it outputs a single composited file, not separate
+per-speaker tracks. For "two pristine, lined-up audio tracks," the `adelay` step here is
+both simpler and version-proof (it does not depend on the CLI knowing about the gapless
+WAV feature). See the CLI section for the composite path:
+https://docs.daily.co/docs/guides/features/recording/index#using-raw-tracks-tools-cli
+
+## Highest quality
+
+Every WAV option is 16-bit PCM lossless and 48 kHz is the top sample rate Daily offers,
+so there is nothing higher to pick. A single mic is mono, so `wav-48k-mono` captures the
+same audio at half the size of stereo. Use stereo only if a downstream tool needs a
+stereo container.
+
+## Run it
+
+Needs `ffmpeg` and `ffprobe` on your PATH (the same tools you already use). Node 24 runs
+the TypeScript directly, no build step.
+
+### 1. Create a room with the right settings
+
+```bash
+node --env-file=.env.local scripts/create-raw-tracks-room.ts
+# add --stereo for a stereo container, or pass a room name:
+# node --env-file=.env.local scripts/create-raw-tracks-room.ts my-room --stereo
+```
+
+This needs `VITE_DAILY_API_KEY` in `.env.local` (already used by this repo). Recordings
+land in the custom S3 bucket configured on your Daily domain.
+
+(Alternative to the room flag: pass `dataOutputs: ["event-json"]` to `startRecording`
+in the app. The room-level flag is the primary path here.)
+
+### 2. Record a 1/1 call
+
+`npm run dev`, open the room in two tabs or two devices, have the second person join a
+few seconds late so the offsets differ, then click **Start Raw-Tracks Recording**. Talk
+over each other a little, then **Stop Recording** and leave.
+
+### 3. Grab the recording with the REST API
+
+```bash
+node --env-file=.env.local scripts/fetch-recording.ts --room raw-tracks --latest
+# or a specific recording:
+# node --env-file=.env.local scripts/fetch-recording.ts <recording_id>
+```
+
+This downloads the event JSON into `raw-tracks-align/sample-data/` and writes a
+`pull-media.sh` with the `aws s3 cp` commands for the track files. The recordings API
+presigns the event JSON, but raw-tracks media lives in your own S3 bucket, so the media
+pull uses your AWS credentials:
+
+```bash
+bash raw-tracks-align/sample-data/pull-media.sh
+```
+
+### 4. Align
+
+```bash
+# validate the event JSON and offsets first, without reading any media:
+node raw-tracks-align/align.ts --dry-run ./raw-tracks-align/sample-data
+
+# then produce the aligned tracks:
+node raw-tracks-align/align.ts ./raw-tracks-align/sample-data
+```
+
+You get one WAV per speaker under `sample-data/aligned/`, all the same length and
+front-aligned to the session start.
+
+### 5. Check it
+
+```bash
+# durations match
+for f in raw-tracks-align/sample-data/aligned/*.wav; do
+  echo -n "$f: "; ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$f"
+done
+
+# a late joiner's file has leading silence equal to its start offset
+ffmpeg -hide_banner -i raw-tracks-align/sample-data/aligned/<late-speaker>.wav \
+  -af silencedetect=n=-50dB:d=0.1 -f null -
+```
+
+## Event JSON format
+
+`parseEvents()` in `align.ts` is the only part tied to the event JSON shape. It is
+written against the real `daily-event-json` format (`format_version` `2026-04-30`) and
+verified against a live recording. It reads the `recording-media-started` events and
+uses, per audio file, `participant_id`, `data.uri` (the file), and `data.mediaStartTime`
+(epoch seconds) as the start on the session timeline. Everything else (offsets, ffmpeg)
+is schema-independent. If the format version changes, that one function is the only thing
+to update.
+
+## Note on audio format
+
+This works on whatever raw-tracks audio you have, but you get the cheap, lossless path
+only when the room sets `enable_raw_tracks_transcoded_audio` (gapless WAV). Without it,
+the audio files are `audio/webm` (Opus): alignment still works, but ffmpeg has to decode
+them and internal gaps are not pre-filled. The room created by
+`scripts/create-raw-tracks-room.ts` sets the gapless WAV property for you.

--- a/raw-tracks-align/README.md
+++ b/raw-tracks-align/README.md
@@ -16,6 +16,11 @@ The whole thing is cheap because you let Daily do the hard part during the recor
    onto one timeline, then `apad` to a shared length. On 16-bit PCM this is near-instant:
    no decode, no re-encode.
 
+> **WAV only.** `align.ts` is built for gapless WAV (step 1). Default raw-tracks `.webm`
+> has no duration header and a skewed start timestamp, so the aligner stops with a clear
+> message rather than guessing. Always record with `enable_raw_tracks_transcoded_audio`
+> (the room script below sets it).
+
 Docs:
 - Gapless transcoded audio: https://docs.daily.co/docs/guides/features/recording/index#gapless-transcoded-audio
 - `enable_raw_tracks_event_json` (Apr 29 2026 changelog): https://docs.daily.co/changelog/077-2026-04-29#media-services
@@ -69,13 +74,23 @@ node --env-file=.env.local scripts/fetch-recording.ts --room raw-tracks --latest
 ```
 
 This downloads the event JSON into `raw-tracks-align/sample-data/` and writes a
-`pull-media.sh` with the `aws s3 cp` commands for the track files. The recordings API
-presigns the event JSON, but raw-tracks media lives in your own S3 bucket, so the media
-pull uses your AWS credentials:
+`pull-media.sh` with the `aws s3 cp` commands for the **audio** track files (the aligner
+does not need the video). The recordings API presigns the event JSON, but raw-tracks media
+lives in your own S3 bucket, so the media pull uses your AWS credentials:
 
 ```bash
 bash raw-tracks-align/sample-data/pull-media.sh
 ```
+
+If that returns a `403`, your default AWS identity cannot read the bucket. Run it with the
+profile that owns the bucket:
+
+```bash
+AWS_PROFILE=your-profile bash raw-tracks-align/sample-data/pull-media.sh
+```
+
+Keep one recording per directory. The aligner reads the single event JSON it finds there,
+so if you want to align a second recording, fetch it into its own folder with `--out`.
 
 ### 4. Align
 

--- a/raw-tracks-align/align.ts
+++ b/raw-tracks-align/align.ts
@@ -57,7 +57,7 @@ const FFPROBE = process.env.FFPROBE ?? "ffprobe";
 
 /** A media file referenced by the event JSON, before it is matched to a local file. */
 type TrackRef = {
-  participant: string;
+  speaker: string; // user_id when set, else participant_id (see below)
   fileBase: string; // basename of the s3 uri, no directory
   startTsMs: number;
 };
@@ -69,6 +69,7 @@ type MediaStartedEvent = {
     uri?: string;
     contentType?: string;
     mediaStartTime?: number;
+    user_id?: string;
   };
 };
 
@@ -110,8 +111,11 @@ function parseEvents(dir: string): TrackRef[] {
       if (!uri || typeof mediaStartTime !== "number" || !e.participant_id) {
         throw new Error(`Incomplete recording-media-started event: ${JSON.stringify(e)}`);
       }
+      // Group by the app-set user_id when present. A reconnect (leave + rejoin) reuses the
+      // same user_id but gets a NEW participant_id, so user_id is what merges a speaker's
+      // two files back together. Fall back to participant_id when no user_id was set.
       return {
-        participant: e.participant_id,
+        speaker: e.data?.user_id || e.participant_id,
         fileBase: basename(uri),
         startTsMs: Math.round(mediaStartTime * 1000), // epoch seconds -> ms
       };
@@ -244,7 +248,7 @@ function main(): void {
     console.log(`Parsed ${refs.length} audio file(s) from the event JSON:`);
     for (const r of refs) {
       const offset = ((r.startTsMs - minStart) / 1000).toFixed(3);
-      console.log(`  ${r.participant}  +${offset}s  ${r.fileBase}`);
+      console.log(`  ${r.speaker}  +${offset}s  ${r.fileBase}`);
     }
     console.log("Dry run: offsets only, no media read and no output written.");
     return;
@@ -252,26 +256,27 @@ function main(): void {
 
   const withFiles = refs.map((r) => {
     const file = resolveFile(inputDir, r.fileBase);
-    return { participant: r.participant, file, offsetMs: r.startTsMs - minStart, durMs: durationMs(file) };
+    return { speaker: r.speaker, file, offsetMs: r.startTsMs - minStart, durMs: durationMs(file) };
   });
 
   const targetMs = Math.max(...withFiles.map((t) => t.offsetMs + t.durMs));
 
-  const byParticipant = new Map<string, { file: string; offsetMs: number }[]>();
+  // Group each speaker's files (a reconnect gives one speaker more than one file).
+  const bySpeaker = new Map<string, { file: string; offsetMs: number }[]>();
   for (const t of withFiles) {
-    const list = byParticipant.get(t.participant) ?? [];
+    const list = bySpeaker.get(t.speaker) ?? [];
     list.push({ file: t.file, offsetMs: t.offsetMs });
-    byParticipant.set(t.participant, list);
+    bySpeaker.set(t.speaker, list);
   }
 
   const outDir = join(inputDir, "aligned");
   mkdirSync(outDir, { recursive: true });
 
-  console.log(`Target length: ${(targetMs / 1000).toFixed(3)}s across ${byParticipant.size} speaker(s)`);
-  for (const [participant, files] of byParticipant) {
-    const outFile = join(outDir, `${safeName(participant)}.wav`);
+  console.log(`Target length: ${(targetMs / 1000).toFixed(3)}s across ${bySpeaker.size} speaker(s)`);
+  for (const [speaker, files] of bySpeaker) {
+    const outFile = join(outDir, `${safeName(speaker)}.wav`);
     const offsets = files.map((f) => `${(f.offsetMs / 1000).toFixed(2)}s`).join(", ");
-    console.log(`  ${participant}: ${files.length} file(s), offsets [${offsets}] -> ${outFile}`);
+    console.log(`  ${speaker}: ${files.length} file(s), offsets [${offsets}] -> ${outFile}`);
     alignParticipant(files, targetMs, outFile);
   }
   console.log("Done. Each output is the same length and front-aligned to the session start.");

--- a/raw-tracks-align/align.ts
+++ b/raw-tracks-align/align.ts
@@ -16,6 +16,10 @@
  * Input dir holds the raw-tracks .wav files plus the event JSON. Output is written to
  * <input-dir>/aligned/<speaker>.wav.
  *
+ * WAV-ONLY: this expects gapless WAV input (enable_raw_tracks_transcoded_audio). It does
+ * not handle default raw-tracks .webm; see durationMs() for why. Use a room created by
+ * scripts/create-raw-tracks-room.ts.
+ *
  * Requires ffmpeg + ffprobe on PATH (the same tools the customer already uses). If you
  * want zero system deps, swap in ffmpeg-static / ffprobe-static and point FFMPEG/FFPROBE
  * at them.
@@ -69,10 +73,19 @@ type MediaStartedEvent = {
 };
 
 function parseEvents(dir: string): TrackRef[] {
-  const jsonName = readdirSync(dir).find((f) => f.toLowerCase().endsWith(".json"));
-  if (!jsonName) {
+  const jsonFiles = readdirSync(dir).filter((f) => f.toLowerCase().endsWith(".json"));
+  if (jsonFiles.length === 0) {
     throw new Error(`No .json event file found in ${dir}`);
   }
+  // One recording per directory. Two event JSONs means two recordings got mixed together,
+  // and silently picking one would align the wrong session. Stop and say so.
+  if (jsonFiles.length > 1) {
+    throw new Error(
+      `Found ${jsonFiles.length} .json files in ${dir} (${jsonFiles.join(", ")}). ` +
+        `Keep one recording per directory: fetch each with its own --out dir.`
+    );
+  }
+  const jsonName = jsonFiles[0];
   const doc = JSON.parse(readFileSync(join(dir, jsonName), "utf8")) as {
     format_id?: string;
     events?: MediaStartedEvent[];
@@ -133,13 +146,32 @@ function resolveFile(dir: string, fileBase: string): string {
 // Alignment (schema-independent from here down)
 // ---------------------------------------------------------------------------
 
+// Per-file duration is the ONE value we cannot get from the event JSON: it has no media
+// end time, and the recording-media-finished / track-removed event timestamps overshoot
+// the real media length by 1-5s (upload + teardown lag). We read it from the media's own
+// duration header.
+//
+// This is WAV-only on purpose. Gapless WAV (enable_raw_tracks_transcoded_audio) always
+// carries a duration header and starts cleanly at timestamp zero, which is what keeps the
+// align step exact and "no decode, no re-encode" fast. Default raw-tracks .webm has no
+// duration header (ffprobe returns "N/A") and a skewed start timestamp, so we stop with a
+// clear message instead of guessing. Record in a room from create-raw-tracks-room.ts.
 function durationMs(file: string): number {
-  const out = execFileSync(
-    FFPROBE,
-    ["-v", "error", "-show_entries", "format=duration", "-of", "default=nw=1:nk=1", file],
-    { encoding: "utf8" }
-  ).trim();
-  return Math.round(Number(out) * 1000);
+  const probed = Number(
+    execFileSync(
+      FFPROBE,
+      ["-v", "error", "-show_entries", "format=duration", "-of", "default=nw=1:nk=1", file],
+      { encoding: "utf8" }
+    ).trim()
+  );
+  if (!Number.isFinite(probed)) {
+    throw new Error(
+      `Could not read a duration from ${basename(file)}. This tool only handles gapless WAV ` +
+        `(enable_raw_tracks_transcoded_audio); a .webm raw-tracks file has no duration header. ` +
+        `Record in a room created by scripts/create-raw-tracks-room.ts, which sets that property.`
+    );
+  }
+  return Math.round(probed * 1000);
 }
 
 function safeName(participant: string): string {
@@ -245,4 +277,9 @@ function main(): void {
   console.log("Done. Each output is the same length and front-aligned to the session start.");
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+}

--- a/raw-tracks-align/align.ts
+++ b/raw-tracks-align/align.ts
@@ -1,0 +1,248 @@
+/**
+ * Line up Daily raw-tracks audio into one equal-length, front-aligned WAV per speaker.
+ *
+ * Why this is simple and cheap:
+ *   - Record gapless WAV (enable_raw_tracks_transcoded_audio: wav-48k-mono), so each file
+ *     is already continuous: no internal mute/packet-loss holes to patch.
+ *   - The event JSON (enable_raw_tracks_event_json) gives each file's start offset on the
+ *     session timeline. That offset is the whole trick.
+ *   - For each speaker: adelay each file to its offset, overlay the fragments onto one
+ *     timeline, then apad to a shared length. On PCM this is near-instant: no decode,
+ *     no re-encode.
+ *
+ * Usage (Node 24 runs the .ts file directly, no build step):
+ *   node raw-tracks-align/align.ts ./sample-data
+ *
+ * Input dir holds the raw-tracks .wav files plus the event JSON. Output is written to
+ * <input-dir>/aligned/<speaker>.wav.
+ *
+ * Requires ffmpeg + ffprobe on PATH (the same tools the customer already uses). If you
+ * want zero system deps, swap in ffmpeg-static / ffprobe-static and point FFMPEG/FFPROBE
+ * at them.
+ *
+ * Docs:
+ *   https://docs.daily.co/docs/guides/features/recording/index#gapless-transcoded-audio
+ *   https://docs.daily.co/changelog/077-2026-04-29#media-services
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const FFMPEG = process.env.FFMPEG ?? "ffmpeg";
+const FFPROBE = process.env.FFPROBE ?? "ffprobe";
+
+// ---------------------------------------------------------------------------
+// parseEvents: the ONLY part tied to the event JSON shape.
+//
+// Written against the real raw-tracks event JSON (format_id "daily-event-json",
+// format_version "2026-04-30"). Shape:
+//   {
+//     "format_id": "daily-event-json",
+//     "events": [
+//       { "type": "recording-media-started", "participant_id": "...",
+//         "data": { "uri": "s3://.../<file>", "contentType": "audio/webm",
+//                   "mediaStartTime": 1782199853.618 } },
+//       ... (track-added, track-removed, recording-media-finished too)
+//     ]
+//   }
+// We only need the "recording-media-started" audio events: each gives the participant,
+// the file (basename of data.uri), and data.mediaStartTime (epoch SECONDS) as the start
+// on the session timeline. Everything below this function is schema-independent.
+// ---------------------------------------------------------------------------
+
+/** A media file referenced by the event JSON, before it is matched to a local file. */
+type TrackRef = {
+  participant: string;
+  fileBase: string; // basename of the s3 uri, no directory
+  startTsMs: number;
+};
+
+type MediaStartedEvent = {
+  type: string;
+  participant_id?: string;
+  data?: {
+    uri?: string;
+    contentType?: string;
+    mediaStartTime?: number;
+  };
+};
+
+function parseEvents(dir: string): TrackRef[] {
+  const jsonName = readdirSync(dir).find((f) => f.toLowerCase().endsWith(".json"));
+  if (!jsonName) {
+    throw new Error(`No .json event file found in ${dir}`);
+  }
+  const doc = JSON.parse(readFileSync(join(dir, jsonName), "utf8")) as {
+    format_id?: string;
+    events?: MediaStartedEvent[];
+  };
+
+  if (doc.format_id !== "daily-event-json") {
+    console.warn(
+      `Warning: ${jsonName} format_id is "${doc.format_id}", expected "daily-event-json". parseEvents() may need updating.`
+    );
+  }
+  const events = doc.events ?? [];
+
+  const refs = events
+    .filter(
+      (e) =>
+        e.type === "recording-media-started" &&
+        String(e.data?.contentType ?? "").toLowerCase().startsWith("audio")
+    )
+    .map((e): TrackRef => {
+      const uri = e.data?.uri;
+      const mediaStartTime = e.data?.mediaStartTime;
+      if (!uri || typeof mediaStartTime !== "number" || !e.participant_id) {
+        throw new Error(`Incomplete recording-media-started event: ${JSON.stringify(e)}`);
+      }
+      return {
+        participant: e.participant_id,
+        fileBase: basename(uri),
+        startTsMs: Math.round(mediaStartTime * 1000), // epoch seconds -> ms
+      };
+    });
+
+  if (refs.length === 0) {
+    throw new Error(
+      `No audio "recording-media-started" events found in ${jsonName}. Check parseEvents() against the event JSON.`
+    );
+  }
+  return refs;
+}
+
+/**
+ * Match an event-JSON file reference to an actual file on disk. The s3 uri basename has
+ * no extension; downloaded files may keep that exact name or add one (e.g. .webm/.wav).
+ */
+function resolveFile(dir: string, fileBase: string): string {
+  const candidates = readdirSync(dir).filter(
+    (f) => f === fileBase || f.startsWith(`${fileBase}.`)
+  );
+  if (candidates.length === 0) {
+    throw new Error(
+      `Event JSON references "${fileBase}" but no matching file is in ${dir}. ` +
+        `Download the track files next to the event JSON.`
+    );
+  }
+  return join(dir, candidates[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Alignment (schema-independent from here down)
+// ---------------------------------------------------------------------------
+
+function durationMs(file: string): number {
+  const out = execFileSync(
+    FFPROBE,
+    ["-v", "error", "-show_entries", "format=duration", "-of", "default=nw=1:nk=1", file],
+    { encoding: "utf8" }
+  ).trim();
+  return Math.round(Number(out) * 1000);
+}
+
+function safeName(participant: string): string {
+  return participant.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function alignParticipant(
+  files: { file: string; offsetMs: number }[],
+  targetMs: number,
+  outFile: string
+): void {
+  const inputs: string[] = [];
+  const chains: string[] = [];
+  files.forEach((f, i) => {
+    inputs.push("-i", f.file);
+    chains.push(`[${i}]adelay=${f.offsetMs}:all=1[a${i}]`);
+  });
+
+  const labels = files.map((_, i) => `[a${i}]`).join("");
+  const mix =
+    files.length > 1
+      ? `${labels}amix=inputs=${files.length}:normalize=0,apad[out]`
+      : `[a0]apad[out]`;
+  const filter = [...chains, mix].join(";");
+
+  const targetSec = (targetMs / 1000).toFixed(3);
+
+  execFileSync(
+    FFMPEG,
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-y",
+      ...inputs,
+      "-filter_complex",
+      filter,
+      "-map",
+      "[out]",
+      "-t",
+      targetSec,
+      "-c:a",
+      "pcm_s16le",
+      "-ar",
+      "48000",
+      outFile,
+    ],
+    { stdio: ["ignore", "ignore", "inherit"] }
+  );
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const inputDir = args.find((a) => !a.startsWith("--")) ?? "./sample-data";
+  if (!existsSync(inputDir)) {
+    console.error(`Input dir not found: ${inputDir}`);
+    process.exit(1);
+  }
+
+  const refs = parseEvents(inputDir);
+
+  // Offsets are relative to the earliest file (recording start, for a 1/1 where one
+  // joined first).
+  const minStart = Math.min(...refs.map((r) => r.startTsMs));
+
+  // --dry-run validates the event JSON (parser + offsets) without reading any media,
+  // so you can sanity-check before downloading the track files.
+  if (dryRun) {
+    console.log(`Parsed ${refs.length} audio file(s) from the event JSON:`);
+    for (const r of refs) {
+      const offset = ((r.startTsMs - minStart) / 1000).toFixed(3);
+      console.log(`  ${r.participant}  +${offset}s  ${r.fileBase}`);
+    }
+    console.log("Dry run: offsets only, no media read and no output written.");
+    return;
+  }
+
+  const withFiles = refs.map((r) => {
+    const file = resolveFile(inputDir, r.fileBase);
+    return { participant: r.participant, file, offsetMs: r.startTsMs - minStart, durMs: durationMs(file) };
+  });
+
+  const targetMs = Math.max(...withFiles.map((t) => t.offsetMs + t.durMs));
+
+  const byParticipant = new Map<string, { file: string; offsetMs: number }[]>();
+  for (const t of withFiles) {
+    const list = byParticipant.get(t.participant) ?? [];
+    list.push({ file: t.file, offsetMs: t.offsetMs });
+    byParticipant.set(t.participant, list);
+  }
+
+  const outDir = join(inputDir, "aligned");
+  mkdirSync(outDir, { recursive: true });
+
+  console.log(`Target length: ${(targetMs / 1000).toFixed(3)}s across ${byParticipant.size} speaker(s)`);
+  for (const [participant, files] of byParticipant) {
+    const outFile = join(outDir, `${safeName(participant)}.wav`);
+    const offsets = files.map((f) => `${(f.offsetMs / 1000).toFixed(2)}s`).join(", ");
+    console.log(`  ${participant}: ${files.length} file(s), offsets [${offsets}] -> ${outFile}`);
+    alignParticipant(files, targetMs, outFile);
+  }
+  console.log("Done. Each output is the same length and front-aligned to the session start.");
+}
+
+main();

--- a/raw-tracks-align/align.ts
+++ b/raw-tracks-align/align.ts
@@ -183,7 +183,7 @@ function safeName(participant: string): string {
 }
 
 function alignParticipant(
-  files: { file: string; offsetMs: number }[],
+  files: { file: string; offsetMs: number; durMs: number }[],
   targetMs: number,
   outFile: string
 ): void {
@@ -191,7 +191,15 @@ function alignParticipant(
   const chains: string[] = [];
   files.forEach((f, i) => {
     inputs.push("-i", f.file);
-    chains.push(`[${i}]adelay=${f.offsetMs}:all=1[a${i}]`);
+    // A WebRTC track ends (and sometimes starts) abruptly, so the join with the surrounding
+    // silence is a hard step: an audible click and a full-scale spike in the waveform. A
+    // short fade in/out at each fragment's edges ramps it to zero instead. 10 ms is below
+    // what you can hear on speech.
+    const fadeSec = Math.min(0.01, f.durMs / 1000 / 4);
+    const fadeOutStart = (f.durMs / 1000 - fadeSec).toFixed(4);
+    chains.push(
+      `[${i}]afade=t=in:d=${fadeSec},afade=t=out:st=${fadeOutStart}:d=${fadeSec},adelay=${f.offsetMs}:all=1[a${i}]`
+    );
   });
 
   const labels = files.map((_, i) => `[a${i}]`).join("");
@@ -262,10 +270,10 @@ function main(): void {
   const targetMs = Math.max(...withFiles.map((t) => t.offsetMs + t.durMs));
 
   // Group each speaker's files (a reconnect gives one speaker more than one file).
-  const bySpeaker = new Map<string, { file: string; offsetMs: number }[]>();
+  const bySpeaker = new Map<string, { file: string; offsetMs: number; durMs: number }[]>();
   for (const t of withFiles) {
     const list = bySpeaker.get(t.speaker) ?? [];
-    list.push({ file: t.file, offsetMs: t.offsetMs });
+    list.push({ file: t.file, offsetMs: t.offsetMs, durMs: t.durMs });
     bySpeaker.set(t.speaker, list);
   }
 

--- a/raw-tracks-align/sample-data/.gitignore
+++ b/raw-tracks-align/sample-data/.gitignore
@@ -1,0 +1,5 @@
+# Keep the folder tracked, but never commit downloaded recordings, event JSON,
+# pull scripts, or aligned output (real session data + large media).
+*
+!.gitkeep
+!.gitignore

--- a/raw-tracks-align/sample-data/.gitkeep
+++ b/raw-tracks-align/sample-data/.gitkeep
@@ -1,0 +1,3 @@
+# Drop the recording's raw-tracks .wav files and the event JSON here, then run:
+#   node raw-tracks-align/align.ts ./raw-tracks-align/sample-data
+# Output WAVs are written to ./aligned/ inside this folder.

--- a/scripts/create-raw-tracks-room.ts
+++ b/scripts/create-raw-tracks-room.ts
@@ -1,0 +1,100 @@
+/**
+ * Create a Daily room set up for the raw-tracks audio line-up demo.
+ *
+ * It sets three room properties that make per-speaker alignment easy later:
+ *   - enable_recording: "raw-tracks"            -> one file per participant track
+ *   - enable_raw_tracks_transcoded_audio        -> gapless, lossless WAV (no internal holes)
+ *   - enable_raw_tracks_event_json: true         -> per-file start offsets in an event JSON
+ *
+ * Run it with Node 24 (reads .env.local and runs the .ts file directly):
+ *   node --env-file=.env.local scripts/create-raw-tracks-room.ts
+ *   node --env-file=.env.local scripts/create-raw-tracks-room.ts my-room-name
+ *   node --env-file=.env.local scripts/create-raw-tracks-room.ts my-room-name --stereo
+ *
+ * Needs VITE_DAILY_API_KEY in .env.local (already used by this repo).
+ *
+ * Docs:
+ *   https://docs.daily.co/docs/guides/features/recording/index#gapless-transcoded-audio
+ *   https://docs.daily.co/changelog/077-2026-04-29#media-services  (enable_raw_tracks_event_json)
+ */
+
+// "highest quality" note: every WAV option is 16-bit PCM lossless and 48 kHz is the top
+// sample rate Daily offers, so there is nothing higher to pick. A single mic is mono, so
+// mono captures the same audio at half the size. Pass --stereo only if you need a stereo
+// container downstream.
+type TranscodedAudio = "wav-48k-mono" | "wav-48k-stereo";
+
+type RoomProperties = {
+  enable_recording: "raw-tracks";
+  enable_raw_tracks_transcoded_audio: TranscodedAudio;
+  enable_raw_tracks_event_json: boolean;
+};
+
+const API_URL = "https://api.daily.co/v1/rooms";
+
+function parseArgs(argv: string[]): { name?: string; stereo: boolean } {
+  const args = argv.slice(2);
+  const stereo = args.includes("--stereo");
+  const name = args.find((a) => !a.startsWith("--"));
+  return { name, stereo };
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.VITE_DAILY_API_KEY;
+  if (!apiKey) {
+    console.error(
+      "Missing VITE_DAILY_API_KEY. Run with: node --env-file=.env.local scripts/create-raw-tracks-room.ts"
+    );
+    process.exit(1);
+  }
+
+  const { name, stereo } = parseArgs(process.argv);
+
+  const properties: RoomProperties = {
+    enable_recording: "raw-tracks",
+    enable_raw_tracks_transcoded_audio: stereo ? "wav-48k-stereo" : "wav-48k-mono",
+    enable_raw_tracks_event_json: true,
+  };
+
+  const body: { name?: string; properties: RoomProperties } = { properties };
+  if (name) body.name = name;
+
+  const res = await fetch(API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  if (!res.ok) {
+    console.error(`Room creation failed (${res.status}):`, text);
+    process.exit(1);
+  }
+
+  const room = JSON.parse(text) as {
+    name: string;
+    url: string;
+    config: Partial<RoomProperties>;
+  };
+
+  console.log("Created room:", room.url);
+  console.log("Properties set on the room:");
+  console.log("  enable_recording:", room.config.enable_recording);
+  console.log(
+    "  enable_raw_tracks_transcoded_audio:",
+    room.config.enable_raw_tracks_transcoded_audio
+  );
+  console.log(
+    "  enable_raw_tracks_event_json:",
+    room.config.enable_raw_tracks_event_json
+  );
+  console.log("\nPaste this room URL into the app, then start a raw-tracks recording.");
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/scripts/fetch-recording.ts
+++ b/scripts/fetch-recording.ts
@@ -115,20 +115,31 @@ async function main(): Promise<void> {
   }
 
   // 2. Track files live in your S3 bucket. Emit aws-cli commands to pull them.
+  // Audio only: the aligner uses just the audio tracks, so there is no reason to pull the
+  // (much larger) video files.
   const tracks = rec.tracks ?? [];
   const audio = tracks.filter((t) => t.content_type?.startsWith("audio"));
   const bucket = link.s3_bucket;
   if (!bucket) {
     console.warn("No s3_bucket in the access-link response; cannot build pull commands.");
   } else {
-    const lines = ["#!/usr/bin/env bash", "set -euo pipefail", ""];
-    for (const t of tracks) {
+    const lines = [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "",
+      "# Raw-tracks media lives in your own S3 bucket, not in Daily's. If your default AWS",
+      "# identity cannot read it (403), run with the profile that owns the bucket, e.g.:",
+      "#   AWS_PROFILE=your-profile bash pull-media.sh",
+      "",
+    ];
+    for (const t of audio) {
       lines.push(`aws s3 cp "s3://${bucket}/${t.s3Key}" "${join(args.out, basename(t.s3Key))}"`);
     }
     const sh = join(args.out, "pull-media.sh");
     writeFileSync(sh, lines.join("\n") + "\n");
-    console.log(`Wrote ${tracks.length} track download command(s) -> ${sh}`);
-    console.log(`Run it with your AWS credentials for bucket "${bucket}":  bash ${sh}`);
+    console.log(`Wrote ${audio.length} audio track download command(s) -> ${sh}`);
+    console.log(`Run it with AWS creds that can read bucket "${bucket}":  bash ${sh}`);
+    console.log(`(If you get a 403, prefix it with the right profile: AWS_PROFILE=... bash ${sh})`);
   }
 
   // Heads-up if this recording is not gapless WAV.

--- a/scripts/fetch-recording.ts
+++ b/scripts/fetch-recording.ts
@@ -1,0 +1,149 @@
+/**
+ * Grab a raw-tracks recording with the Daily REST API: download the event JSON, and
+ * write the aws-cli commands to pull the track files from your S3 bucket.
+ *
+ * The recordings API presigns the event JSON for you, but raw-tracks media lives in your
+ * own custom S3 bucket and is not presigned per-track. So this script downloads the
+ * event JSON directly and emits a pull-media.sh you run with your own AWS credentials.
+ *
+ * Usage (Node 24):
+ *   node --env-file=.env.local scripts/fetch-recording.ts <recording_id>
+ *   node --env-file=.env.local scripts/fetch-recording.ts --room raw-tracks --latest
+ *   node --env-file=.env.local scripts/fetch-recording.ts <recording_id> --out ./raw-tracks-align/sample-data
+ *
+ * Needs VITE_DAILY_API_KEY in .env.local.
+ *
+ * Docs:
+ *   List recordings:  https://docs.daily.co/reference/rest-api/recordings/list-recordings
+ *   Get recording:    https://docs.daily.co/reference/rest-api/recordings/get-recording
+ *   Get access link:  https://docs.daily.co/reference/rest-api/recordings/get-recording-link
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const API = "https://api.daily.co/v1";
+
+type Track = { type: string; content_type: string; s3Key: string };
+type Recording = {
+  id: string;
+  room_name?: string;
+  status: string;
+  duration?: number;
+  tracks?: Track[] | null;
+  data_outputs?: string[];
+};
+type AccessLink = {
+  s3_bucket?: string;
+  s3_region?: string;
+  data_outputs?: Record<string, string>;
+};
+
+function authHeaders(key: string): Record<string, string> {
+  return { Authorization: `Bearer ${key}` };
+}
+
+async function getJson<T>(url: string, key: string): Promise<T> {
+  const res = await fetch(url, { headers: authHeaders(key) });
+  const body = await res.text();
+  if (!res.ok) throw new Error(`GET ${url} -> ${res.status}: ${body}`);
+  return JSON.parse(body) as T;
+}
+
+function parseArgs(argv: string[]): {
+  id?: string;
+  room?: string;
+  latest: boolean;
+  out: string;
+} {
+  const args = argv.slice(2);
+  const valueAfter = (flag: string): string | undefined => {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  return {
+    id: args.find((a) => !a.startsWith("--") && args[args.indexOf(a) - 1]?.startsWith("--") !== true),
+    room: valueAfter("--room"),
+    latest: args.includes("--latest"),
+    out: valueAfter("--out") ?? "./raw-tracks-align/sample-data",
+  };
+}
+
+async function resolveRecordingId(
+  args: { id?: string; room?: string; latest: boolean },
+  key: string
+): Promise<string> {
+  if (args.id) return args.id;
+  if (args.room && args.latest) {
+    const list = await getJson<{ data: Recording[] }>(
+      `${API}/recordings?room_name=${encodeURIComponent(args.room)}&limit=1`,
+      key
+    );
+    const rec = list.data?.[0];
+    if (!rec) throw new Error(`No recordings found for room "${args.room}"`);
+    return rec.id;
+  }
+  throw new Error("Provide a <recording_id>, or --room <name> --latest");
+}
+
+async function main(): Promise<void> {
+  const key = process.env.VITE_DAILY_API_KEY;
+  if (!key) {
+    console.error("Missing VITE_DAILY_API_KEY. Run with: node --env-file=.env.local scripts/fetch-recording.ts ...");
+    process.exit(1);
+  }
+
+  const args = parseArgs(process.argv);
+  const id = await resolveRecordingId(args, key);
+
+  const rec = await getJson<Recording>(`${API}/recordings/${id}`, key);
+  const link = await getJson<AccessLink>(`${API}/recordings/${id}/access-link`, key);
+
+  mkdirSync(args.out, { recursive: true });
+
+  // 1. Event JSON (presigned by the API).
+  const eventJsonUrl = link.data_outputs?.["event-json"];
+  if (!eventJsonUrl) {
+    console.warn(
+      "No event-json in this recording's data_outputs. Record with enable_raw_tracks_event_json (or dataOutputs: ['event-json'])."
+    );
+  } else {
+    const text = await (await fetch(eventJsonUrl)).text();
+    const eventPath = join(args.out, `${id}.event.json`);
+    writeFileSync(eventPath, text);
+    console.log(`Saved event JSON -> ${eventPath}`);
+  }
+
+  // 2. Track files live in your S3 bucket. Emit aws-cli commands to pull them.
+  const tracks = rec.tracks ?? [];
+  const audio = tracks.filter((t) => t.content_type?.startsWith("audio"));
+  const bucket = link.s3_bucket;
+  if (!bucket) {
+    console.warn("No s3_bucket in the access-link response; cannot build pull commands.");
+  } else {
+    const lines = ["#!/usr/bin/env bash", "set -euo pipefail", ""];
+    for (const t of tracks) {
+      lines.push(`aws s3 cp "s3://${bucket}/${t.s3Key}" "${join(args.out, basename(t.s3Key))}"`);
+    }
+    const sh = join(args.out, "pull-media.sh");
+    writeFileSync(sh, lines.join("\n") + "\n");
+    console.log(`Wrote ${tracks.length} track download command(s) -> ${sh}`);
+    console.log(`Run it with your AWS credentials for bucket "${bucket}":  bash ${sh}`);
+  }
+
+  // Heads-up if this recording is not gapless WAV.
+  const nonWav = audio.find((t) => t.content_type !== "audio/wav");
+  if (nonWav) {
+    console.log(
+      `\nNote: audio tracks are "${nonWav.content_type}", not gapless WAV. For the lossless, gap-filled path,\n` +
+        `record in a room created by scripts/create-raw-tracks-room.ts (sets enable_raw_tracks_transcoded_audio).`
+    );
+  }
+
+  console.log(`\nThen align:  node raw-tracks-align/align.ts ${args.out}`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -582,6 +582,20 @@ export default function App() {
           Stop Recording
         </button>
         <br />
+        {/*
+          Raw-tracks recording: one file per participant track. Pair this with a room
+          created by scripts/create-raw-tracks-room.ts, which also sets
+          enable_raw_tracks_transcoded_audio (gapless WAV) and enable_raw_tracks_event_json
+          (per-file start offsets). After the call, line the tracks up with
+          raw-tracks-align/align.ts. Stop it with the Stop Recording button above.
+        */}
+        <button
+          disabled={isRecording}
+          onClick={() => startRecording({ type: "raw-tracks" })}
+        >
+          Start Raw-Tracks Recording
+        </button>
+        <br />
         <button
           onClick={() => {
             if (isTranscribing) {


### PR DESCRIPTION
## Summary

A demo for lining up Daily raw-tracks audio into separate, equal-length, front-aligned WAVs per speaker (for a 1/1 call). The hard part is done by Daily during the recording; the post-processing is one cheap ffmpeg pass per speaker.

- **`src/App.tsx`**: additive button calling `startRecording({ type: "raw-tracks" })` via the existing `useRecording()` hook. Nothing else in the app changes.
- **`scripts/create-raw-tracks-room.ts`**: creates a room via `POST /rooms` with `enable_recording: "raw-tracks"`, `enable_raw_tracks_transcoded_audio: "wav-48k-mono"` (gapless, lossless), and `enable_raw_tracks_event_json: true`.
- **`scripts/fetch-recording.ts`**: pulls a recording via the REST API (`GET /recordings`, `GET /recordings/:id`, `GET /recordings/:id/access-link`), saves the event JSON, and writes a `pull-media.sh` for the track files.
- **`raw-tracks-align/align.ts`**: reads `recording-media-started` events from the `daily-event-json` (using `participant_id`, `data.uri`, `data.mediaStartTime`), then runs ffmpeg `adelay` (front-pad to each file's offset), `amix` (place reconnect-split fragments on one timeline), and `apad` + `-t` (pad to a shared length) per speaker. Output is one lossless `pcm_s16le` WAV per speaker. Includes a `--dry-run` to validate offsets without media.
- **`raw-tracks-align/README.md`** + `sample-data/` placeholder (with a `.gitignore` so real recordings never get committed).

The scripts are TypeScript run directly under Node 24 (type stripping), no build step.

## Test plan

Verified end to end against a live recording in `hush.daily.co/raw-tracks-gapless`:

- `npm run build` and `npm test` pass (SDK upgrade landed separately on `main`).
- Created the room with `create-raw-tracks-room.ts`; confirmed the three props via `GET /rooms/:name`.
- Recorded a 1/1, then `fetch-recording.ts --room raw-tracks-gapless --latest` saved the event JSON and the pull commands.
- Pulled the media and ran `align.ts`: all three speaker tracks came out **50.881s** (equal length), with leading silence matching each join offset (0s, ~19.6s, ~38.2s) confirmed by `ffmpeg silencedetect`.
- Synthetic test covered the reconnect-split case (`amix`): fragments land at their offsets with the gap preserved.

## Prerequisites

- Room must have the three properties above (use `create-raw-tracks-room.ts`). Audio comes back as gapless `audio/wav`; without `enable_raw_tracks_transcoded_audio` it would be `audio/webm`.
- raw-tracks media lives in your custom S3 bucket; the REST API presigns the event JSON but not the track files, so the media pull uses your own bucket credentials.
- Local tooling: Node 24, `ffmpeg` + `ffprobe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
