### PR TITLE
Demo: backend-driven remove + mute in Prebuilt (no built-in menu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,54 @@ The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+## Remove participant demo (`?demo=remove-participant`)
+
+Shows how to remove and mute participants in Daily Prebuilt WITHOUT the built-in
+"Remove from call..." menu or its "may rejoin" notice.
+
+How it works:
+
+- The admin joins with a **non-admin** meeting token (no `canAdmin`). Because of
+  that, Prebuilt never shows the built-in remove menu or the rejoin notice.
+- A custom tray button (`updateCustomTrayButtons`) opens a small panel listing the
+  other participants.
+- Eject and mute run through a tiny dev-server proxy in `vite.config.ts`
+  (`/api/eject`, `/api/mute`, `/api/session`). The proxy holds the Daily API key,
+  so the key never ships to the browser.
+- "Ask to mute" is the lighter, cooperative path: it sends an app message and the
+  target's own client mutes itself with `setLocalAudio(false)`.
+
+### Setup
+
+Add your Daily API key to `.env.local`, server-side (no `VITE_` prefix so it is
+never bundled):
+
+```
+DAILY_API_KEY=your-daily-api-key
+```
+
+If only `VITE_DAILY_API_KEY` is set, the proxy falls back to it, but the
+un-prefixed key is the safer choice.
+
+### Run it
+
+1. `npm run dev`
+2. Open two windows (use two profiles or one normal + one incognito so they are
+   distinct participants):
+   - Admin: <http://localhost:3000/?demo=remove-participant&admin=true>
+   - Guest: <http://localhost:3000/?demo=remove-participant>
+3. Join both, click **Manage participants** in the admin tray, then try Eject,
+   Mute mic, Stop camera, Restore, and Ask to mute on the guest. Watch the console
+   for `participant-left` / `participant-updated`, and the Network tab for the
+   `/api/*` calls.
+
+Add `&builtinAdmin=true` to an admin window to mint an admin token and SEE the
+built-in remove menu + rejoin notice the customer is trying to avoid.
+
+### Notes
+
+- The proxy only runs under `npm run dev`, not `vite preview`.
+- "Admin" here is app-level only (the `?admin=true` flag controls the UI). In
+  production you would gate that behind your own auth and have your backend
+  authorize the eject/mute calls. This demo is not an authorization model.

--- a/src/RemoveParticipantDemo.tsx
+++ b/src/RemoveParticipantDemo.tsx
@@ -1,0 +1,280 @@
+import "./styles.css";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  DailyProvider,
+  useAppMessage,
+  useCallFrame,
+  useDaily,
+  useDailyEvent,
+  useParticipantIds,
+} from "@daily-co/daily-react";
+import type {
+  DailyEventObject,
+  DailyEventObjectAppMessage,
+  DailyEventObjectCustomButtonClick,
+} from "@daily-co/daily-js";
+
+// Demo: backend-driven participant removal + mute in Daily Prebuilt.
+//
+// The "admin" joins with a NON-admin token, so Prebuilt's built-in "Remove from
+// call..." menu and its rejoin notice never appear. A custom tray button opens a
+// small panel that drives eject + mute through the dev-server proxy (see
+// vite.config.ts), which holds the Daily API key. There is also a cooperative
+// "ask to mute" path over sendAppMessage.
+//
+// Run two windows:
+//   admin: http://localhost:3000/?demo=remove-participant&admin=true
+//   guest: http://localhost:3000/?demo=remove-participant
+// Add &builtinAdmin=true to an admin window to SEE the built-in menu we are avoiding.
+
+interface SessionInfo {
+  roomName: string;
+  roomUrl: string;
+  token: string;
+}
+
+// An https-hosted raw SVG is required: Prebuilt loads it inside an iframe.
+// Iconify serves real image/svg+xml (svgrepo /show/ pages are HTML, not SVG).
+const ADMIN_BUTTON_ICON =
+  "https://api.iconify.design/mdi/account-cog.svg?width=32&height=32";
+
+const params = () => new URLSearchParams(window.location.search);
+const isAdmin = () => params().get("admin") === "true";
+const isBuiltinAdmin = () => params().get("builtinAdmin") === "true";
+
+// A stable per-tab user id. Ban works by user_id, so without a stable id an
+// ejected guest just rejoins on refresh with a fresh random id.
+//
+// Use sessionStorage, NOT localStorage: localStorage is shared across every tab
+// on this origin, so the admin and guest tabs would get the SAME user_id and
+// ejecting one would eject both. sessionStorage is scoped to a single tab but
+// still survives a refresh in that tab, which is exactly what the ban test needs.
+function getUserId(): string {
+  const key = "daily-demo-uid";
+  let id = window.sessionStorage.getItem(key);
+  if (!id) {
+    id = crypto.randomUUID();
+    window.sessionStorage.setItem(key, id);
+  }
+  return id;
+}
+
+async function post(path: string, body: unknown): Promise<unknown> {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return (await res.json()) as unknown;
+}
+
+type DemoAppMessage = DailyEventObjectAppMessage<{ event: string }>;
+
+const panelStyle: React.CSSProperties = {
+  position: "fixed",
+  top: 16,
+  right: 16,
+  width: 320,
+  maxHeight: "70vh",
+  overflowY: "auto",
+  padding: 16,
+  background: "white",
+  border: "1px solid #ccc",
+  borderRadius: 8,
+  boxShadow: "0 2px 12px rgba(0,0,0,0.15)",
+  textAlign: "left",
+  zIndex: 1000,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 6,
+  padding: "8px 0",
+  borderBottom: "1px solid #eee",
+};
+
+function DemoControls() {
+  const callObject = useDaily();
+  const [open, setOpen] = useState(false);
+  const admin = isAdmin();
+
+  const logEvent = useCallback((evt: DailyEventObject) => {
+    if ("action" in evt) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      console.log(`logEvent: ${evt.action}`, evt);
+    } else {
+      console.log("logEvent:", evt);
+    }
+  }, []);
+
+  // Reactive list of everyone but the local participant.
+  const remoteIds = useParticipantIds({
+    filter: "remote",
+    onParticipantLeft: logEvent,
+    onParticipantUpdated: logEvent,
+  });
+
+  // The custom tray button only exists on the admin window, but gate anyway.
+  useDailyEvent(
+    "custom-button-click",
+    useCallback((ev: DailyEventObjectCustomButtonClick) => {
+      if (ev.button_id === "admin-panel") setOpen((o) => !o);
+    }, [])
+  );
+
+  // Receive the cooperative "please mute" request and self-mute. Runs in every
+  // window (admin and guest) because everyone loads this same component.
+  const sendAppMessage = useAppMessage({
+    onAppMessage: useCallback(
+      (ev: DemoAppMessage) => {
+        logEvent(ev);
+        if (ev.data.event === "please-mute") {
+          callObject?.setLocalAudio(false);
+        }
+      },
+      [callObject, logEvent]
+    ),
+  });
+
+  const nameFor = (id: string) => {
+    const name = callObject?.participants()[id]?.user_name;
+    return name ? name : id;
+  };
+
+  const eject = (id: string) => {
+    // Pass the stable user_id so the ban survives a page refresh.
+    const userId = callObject?.participants()[id]?.user_id;
+    void post("/api/eject", { sessionId: id, userId, ban: true });
+  };
+
+  if (!admin || !open) return null;
+
+  return (
+    <div style={panelStyle}>
+      <h3 style={{ marginTop: 0 }}>Manage participants</h3>
+      <p style={{ fontSize: 12, color: "#666", marginTop: 0 }}>
+        This admin has no Daily <code>canAdmin</code>. Eject and mute run through
+        the backend; &quot;ask to mute&quot; is cooperative.
+      </p>
+      {remoteIds.length === 0 && <p>No other participants yet.</p>}
+      {remoteIds.map((id) => (
+        <div key={id} style={rowStyle}>
+          <div style={{ width: "100%" }}>
+            <strong>{nameFor(id)}</strong>
+            <br />
+            <code style={{ fontSize: 11 }}>{id}</code>
+          </div>
+          <button onClick={() => eject(id)}>Eject + ban</button>
+          <button onClick={() => void post("/api/mute", { sessionId: id, canSend: ["video"] })}>
+            Mute mic
+          </button>
+          <button onClick={() => void post("/api/mute", { sessionId: id, canSend: ["audio"] })}>
+            Stop camera
+          </button>
+          <button
+            onClick={() =>
+              void post("/api/mute", { sessionId: id, canSend: ["audio", "video"] })
+            }
+          >
+            Restore
+          </button>
+          <button onClick={() => sendAppMessage({ event: "please-mute" }, id)}>
+            Ask to mute
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function RemoveParticipantDemo() {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [session, setSession] = useState<SessionInfo | null>(null);
+  const [banned, setBanned] = useState(false);
+  const admin = isAdmin();
+
+  // Fetch a room + non-admin token from the backend proxy on mount.
+  useEffect(() => {
+    let cancelled = false;
+    post("/api/session", {
+      admin,
+      builtinAdmin: isBuiltinAdmin(),
+      userId: getUserId(),
+    })
+      .then((info) => {
+        if (cancelled) return;
+        // The backend refuses to issue a token to an ejected + banned user.
+        if (info && typeof info === "object" && "error" in info) {
+          setBanned(true);
+          return;
+        }
+        setSession(info as SessionInfo);
+      })
+      .catch((err) => console.error("session error", err));
+    return () => {
+      cancelled = true;
+    };
+  }, [admin]);
+
+  const callFrame = useCallFrame({
+    // @ts-expect-error will be fixed in the next release (matches Prebuilt.tsx)
+    parentElRef: wrapperRef,
+    options: {
+      url: session?.roomUrl,
+      token: session?.token,
+      dailyConfig: {
+        useDevicePreferenceCookies: true,
+      },
+      iframeStyle: {
+        width: "100%",
+        height: "80vh",
+      },
+      // Only the admin window gets the tray button that opens the panel.
+      ...(admin
+        ? {
+            customTrayButtons: {
+              "admin-panel": {
+                iconPath: ADMIN_BUTTON_ICON,
+                label: "Manage participants",
+                tooltip: "Remove or mute participants",
+                visualState: "default" as const,
+              },
+            },
+          }
+        : {}),
+    },
+    shouldCreateInstance: useCallback(
+      () => Boolean(wrapperRef.current) && Boolean(session),
+      [session]
+    ),
+  });
+
+  useEffect(() => {
+    if (!callFrame || !session) return;
+    // @ts-expect-error debugging
+    window.callObject = callFrame;
+    callFrame.join().catch((err) => {
+      console.error("Error joining call", err);
+    });
+  }, [callFrame, session]);
+
+  if (banned) {
+    return (
+      <div style={{ padding: 48, textAlign: "center" }}>
+        <h2 style={{ color: "#c00" }}>You were removed from the call</h2>
+        <p>
+          Your session was ended and you cannot rejoin. Contact the host if this
+          was unexpected.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <DailyProvider callObject={callFrame}>
+      <div ref={wrapperRef} />
+      <DemoControls />
+    </DailyProvider>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Prebuilt } from "./Prebuilt";
+import { RemoveParticipantDemo } from "./RemoveParticipantDemo";
 import { DailyProvider } from "@daily-co/daily-react";
 import App from "./App";
 
@@ -15,10 +16,13 @@ const root = createRoot(container);
 // Get the value from the url
 const urlParams = new URLSearchParams(window.location.search);
 const isPrebuilt = urlParams.get("prebuilt") ?? false;
+const demo = urlParams.get("demo");
 
 root.render(
   <StrictMode>
-    {isPrebuilt ? (
+    {demo === "remove-participant" ? (
+      <RemoveParticipantDemo />
+    ) : isPrebuilt ? (
       <Prebuilt />
     ) : (
       <DailyProvider

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,185 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv, type Plugin, type Connect } from "vite";
+import type { ServerResponse } from "node:http";
 import react from "@vitejs/plugin-react-swc";
+
+// Backend for the "remove participant" demo (?demo=remove-participant).
+// Keeps the Daily API key server-side so it never reaches the browser bundle.
+// Only runs under `npm run dev` (Vite dev middleware), not `vite preview`.
+const DAILY_API = "https://api.daily.co/v1";
+const DEMO_ROOM = "remove-participant-demo";
+
+function dailyRestProxy(): Plugin {
+  let apiKey = "";
+
+  // Ejected user_ids. Daily's eject-ban does not reliably block a freshly minted
+  // token on rejoin, so we also refuse to issue a token to a banned user. This
+  // mirrors a real app flow: the backend cancels the session so the user cannot
+  // get back in. In-memory only: cleared when the dev server restarts.
+  const bannedUserIds = new Set<string>();
+
+  return {
+    name: "daily-rest-proxy",
+
+    config(_, { mode }) {
+      // Read .env.local. Prefer the un-prefixed key (never bundled); fall back to
+      // the existing VITE_ one so the demo still runs if only that is set.
+      const env = loadEnv(mode, process.cwd(), "");
+      apiKey = env.DAILY_API_KEY || env.VITE_DAILY_API_KEY || "";
+    },
+
+    configureServer(server) {
+      // Call the Daily REST API with the server-side key.
+      const daily = async (
+        path: string,
+        body: unknown
+      ): Promise<{ status: number; json: any }> => {
+        const res = await fetch(`${DAILY_API}${path}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        const text = await res.text();
+        let json: any = {};
+        try {
+          json = text ? JSON.parse(text) : {};
+        } catch {
+          json = { raw: text };
+        }
+        return { status: res.status, json };
+      };
+
+      const readJson = (req: Connect.IncomingMessage): Promise<any> =>
+        new Promise((resolve) => {
+          let data = "";
+          req.on("data", (chunk) => (data += chunk));
+          req.on("end", () => {
+            try {
+              resolve(data ? JSON.parse(data) : {});
+            } catch {
+              resolve({});
+            }
+          });
+        });
+
+      server.middlewares.use(
+        (req: Connect.IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
+          const url = (req.url ?? "").split("?")[0];
+          if (req.method !== "POST" || !url.startsWith("/api/")) {
+            next();
+            return;
+          }
+
+          const send = (status: number, payload: unknown) => {
+            res.statusCode = status;
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify(payload));
+          };
+
+          void (async () => {
+            if (!apiKey) {
+              send(500, {
+                error:
+                  "DAILY_API_KEY not set in .env.local (add it un-prefixed so it stays server-side).",
+              });
+              return;
+            }
+            try {
+              if (url === "/api/session") {
+                const { admin, builtinAdmin, userId } = await readJson(req);
+
+                // Refuse to mint a token for someone who was ejected + banned.
+                if (userId && bannedUserIds.has(userId as string)) {
+                  send(403, { error: "banned" });
+                  return;
+                }
+
+                // Ensure the demo room exists. If it already exists the create
+                // call 400s; in that case fetch it to get the URL.
+                let roomUrl: string | undefined;
+                const created = await daily("/rooms", {
+                  name: DEMO_ROOM,
+                  privacy: "private",
+                });
+                if (created.status === 200) {
+                  roomUrl = created.json.url;
+                } else {
+                  const getRes = await fetch(`${DAILY_API}/rooms/${DEMO_ROOM}`, {
+                    headers: { Authorization: `Bearer ${apiKey}` },
+                  });
+                  const getJson: any = await getRes.json();
+                  roomUrl = getJson.url;
+                }
+
+                // Default tokens are NON-admin (no is_owner, no canAdmin) — that is
+                // the whole point: the built-in remove menu and rejoin notice never
+                // show. builtinAdmin=true mints an admin token so you can SEE the
+                // built-in menu the customer wants gone (before/after comparison).
+                const properties: Record<string, unknown> = {
+                  room_name: DEMO_ROOM,
+                  user_name: admin ? "Admin" : "Guest",
+                };
+                // Stable user_id so an eject+ban survives the guest refreshing.
+                if (userId) {
+                  properties.user_id = userId as string;
+                }
+                if (builtinAdmin) {
+                  properties.permissions = { canAdmin: ["participants"] };
+                }
+                const token = await daily("/meeting-tokens", { properties });
+
+                send(200, {
+                  roomName: DEMO_ROOM,
+                  roomUrl,
+                  token: token.json.token,
+                });
+                return;
+              }
+
+              if (url === "/api/eject") {
+                const { sessionId, userId, ban } = await readJson(req);
+                // Remember the ban so the user can't get a fresh token on refresh.
+                if (ban && userId) {
+                  bannedUserIds.add(userId as string);
+                }
+                // Eject by session id; ban by user_id (that is what ban keys on).
+                const body: Record<string, unknown> = {
+                  ids: [sessionId],
+                  ban: Boolean(ban),
+                };
+                if (userId) {
+                  body.user_ids = [userId as string];
+                }
+                const out = await daily(`/rooms/${DEMO_ROOM}/eject`, body);
+                send(out.status, out.json);
+                return;
+              }
+
+              if (url === "/api/mute") {
+                // canSend is the list of media the participant may still send.
+                // ["video"] = mic muted, ["audio"] = camera off, [] = both blocked,
+                // ["audio","video"] = restored. Dropping a kind turns that track
+                // off server-side (off.byCanSendPermission).
+                const { sessionId, canSend } = await readJson(req);
+                const out = await daily(`/rooms/${DEMO_ROOM}/update-permissions`, {
+                  data: { [sessionId as string]: { canSend } },
+                });
+                send(out.status, out.json);
+                return;
+              }
+
+              next();
+            } catch (err) {
+              send(500, { error: String(err) });
+            }
+          })();
+        }
+      );
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -7,5 +187,5 @@ export default defineConfig({
   server: {
     port: 3000,
   },
-  plugins: [react()],
+  plugins: [react(), dailyRestProxy()],
 });


### PR DESCRIPTION
## What this is

A working demo of how to remove and mute Daily Prebuilt participants **without** the built-in "Remove from call..." menu or its "may rejoin" notice.

Open it at:
- Admin: `http://localhost:3000/?demo=remove-participant&admin=true`
- Guest: `http://localhost:3000/?demo=remove-participant`

Add `&builtinAdmin=true` to an admin window to SEE the built-in menu we are avoiding (before/after).

## How it works

- The admin joins with a **non-admin** meeting token (no `canAdmin`). Because of that, Prebuilt never shows the built-in remove menu or the rejoin notice.
- A custom tray button (`updateCustomTrayButtons`) opens a small panel listing the other participants, each with Eject, Mute mic, Stop camera, Restore, and Ask to mute.
- Eject and mute run through a tiny Vite dev-server proxy (`/api/session`, `/api/eject`, `/api/mute` in `vite.config.ts`). The proxy holds the Daily API key, so the key never ships to the browser.
- The proxy also tracks ejected `user_id`s and **refuses to mint a new token** for them, so a banned guest cannot rejoin on refresh. This mirrors a real app flow where the backend cancels the session.
- "Ask to mute" is the lighter, cooperative path: it sends an app message and the target's own client mutes itself with `setLocalAudio(false)`.

## Setup

Add your Daily API key to `.env.local`, server-side (no `VITE_` prefix):

```
DAILY_API_KEY=your-daily-api-key
```

If only `VITE_DAILY_API_KEY` is set, the proxy falls back to it.

## Notes

- The proxy only runs under `npm run dev`, not `vite preview`. The ban list is in-memory and clears on server restart.
- "Admin" here is app-level only (the `?admin=true` flag). In production you would gate that behind your own auth and have your backend authorize the eject/mute calls. This demo is not an authorization model.
- All changes are additive; existing demos are untouched.

Tested end to end with two windows: eject removes only the target, the banned guest is blocked on refresh, and mute / stop camera / restore / ask-to-mute all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
