### PR TITLE
T-2175 repro: zemplar transcription hallucination on new audio track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 dist/
+t2175-run-log.json
+t2175-silence.wav

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.2",
+        "playwright-core": "^1.61.1",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.17.0",
         "vite": "^5.2.11",
@@ -4666,6 +4667,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.2",
+    "playwright-core": "^1.61.1",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.17.0",
     "vite": "^5.2.11",

--- a/scripts/t2175-run.mjs
+++ b/scripts/t2175-run.mjs
@@ -1,0 +1,157 @@
+// T-2175 zemplar repro: automated one-shot run.
+//
+// - Creates/updates the room + owner token (scripts/t2175-setup.mjs)
+// - Starts the vite dev server
+// - Launches Chromium (playwright-core, uses the cached ms-playwright build)
+//   with a SILENT fake microphone and auto-selected tab capture (with audio)
+// - Joins, waits for transcription-started, then starts a screen share so a
+//   second Deepgram stream opens on the new screen-audio track
+// - Writes every T2175LOG entry to a JSON file and prints a summary
+//
+// Usage: node scripts/t2175-run.mjs [output.json]
+
+import { spawn } from "node:child_process";
+import { writeFileSync, existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright-core";
+import { createRoomAndToken } from "./t2175-setup.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const outPath = process.argv[2] ?? join(repoRoot, "t2175-run-log.json");
+
+function findChromium() {
+  const cache = join(homedir(), "Library/Caches/ms-playwright");
+  const dir = readdirSync(cache)
+    .filter((d) => /^chromium-\d+$/.test(d))
+    .sort()
+    .pop();
+  if (!dir) throw new Error("No cached Playwright Chromium found");
+  const candidates = [
+    "chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+    "chrome-mac/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+    "chrome-mac-arm64/Chromium.app/Contents/MacOS/Chromium",
+    "chrome-mac/Chromium.app/Contents/MacOS/Chromium",
+  ].map((p) => join(cache, dir, p));
+  const exe = candidates.find((p) => existsSync(p));
+  if (!exe) throw new Error(`Chromium binary not found under ${dir}`);
+  return exe;
+}
+
+function writeSilentWav(path, seconds = 5) {
+  const sampleRate = 8000;
+  const numSamples = sampleRate * seconds;
+  const dataSize = numSamples * 2;
+  const buf = Buffer.alloc(44 + dataSize); // samples default to 0 = silence
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36 + dataSize, 4);
+  buf.write("WAVEfmt ", 8);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 2, 28);
+  buf.writeUInt16LE(2, 32);
+  buf.writeUInt16LE(16, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(dataSize, 40);
+  writeFileSync(path, buf);
+}
+
+async function waitForServer(url, timeoutMs = 30000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Dev server not reachable at ${url}`);
+}
+
+async function waitForLogAction(page, action, timeoutMs) {
+  await page.waitForFunction(
+    (a) => (window.__t2175Log ?? []).some((e) => e.action === a),
+    action,
+    { timeout: timeoutMs }
+  );
+}
+
+async function main() {
+  console.log("Creating room + token...");
+  const { roomUrl, appUrl } = await createRoomAndToken();
+  console.log("Room:", roomUrl);
+
+  console.log("Starting vite dev server...");
+  const vite = spawn("npm", ["run", "dev"], { cwd: repoRoot, stdio: "ignore" });
+  let browser;
+  try {
+    await waitForServer("http://localhost:3000/");
+
+    const silenceWav = join(repoRoot, "t2175-silence.wav");
+    writeSilentWav(silenceWav);
+
+    console.log("Launching Chromium...");
+    browser = await chromium.launch({
+      executablePath: findChromium(),
+      headless: false, // tab capture needs a real (headed) browser
+      args: [
+        "--use-fake-ui-for-media-devices",
+        "--use-fake-device-for-media-stream",
+        `--use-file-for-fake-audio-capture=${silenceWav}`,
+        "--auto-select-tab-capture-source-by-title=T2175 Zemplar Repro",
+        "--autoplay-policy=no-user-gesture-required",
+      ],
+    });
+    const page = await browser.newPage();
+    page.on("console", (msg) => {
+      const text = msg.text();
+      if (text.startsWith("T2175LOG")) console.log(text);
+    });
+
+    await page.goto(appUrl);
+
+    console.log("Waiting for join + transcription-started...");
+    await waitForLogAction(page, "joined-meeting", 60000);
+    await waitForLogAction(page, "transcription-started", 60000);
+
+    console.log("Transcription running. 8s of silence before screen share...");
+    await page.waitForTimeout(8000);
+
+    console.log("Starting screen share (new audio track -> new Deepgram ws)...");
+    await page.click("#start-share");
+    await waitForLogAction(page, "local-screen-share-started", 30000);
+
+    console.log("Screen share started. Listening 45s for captions...");
+    await page.waitForTimeout(45000);
+
+    const log = await page.evaluate(() => window.__t2175Log);
+    writeFileSync(outPath, JSON.stringify(log, null, 2));
+    console.log(`\nWrote ${log.length} log entries to ${outPath}`);
+
+    const messages = log.filter((e) => e.action === "transcription-message");
+    console.log(`transcription-message events: ${messages.length}`);
+    for (const m of messages) {
+      console.log(`  [${m.trackType}] "${m.text}"`);
+    }
+    if (messages.length === 0) {
+      console.log(
+        "No captions at all this run (room was silent). The bug is intermittent; rerun to retry."
+      );
+    }
+    const zemplar = messages.some((m) => /zemplar/i.test(String(m.text)));
+    console.log(zemplar ? "*** ZEMPLAR REPRODUCED ***" : "No 'zemplar' this run.");
+  } finally {
+    await browser?.close().catch(() => {});
+    vite.kill("SIGTERM");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/t2175-setup.mjs
+++ b/scripts/t2175-setup.mjs
@@ -1,0 +1,101 @@
+// T-2175 zemplar repro: create (or update) a Daily room with the customer's
+// exact auto_transcription_settings, and mint an owner meeting token with
+// enable_live_captions_ui + auto_start_transcription.
+//
+// Usage: node scripts/t2175-setup.mjs
+// Prints JSON: { roomUrl, token, appUrl }
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOM_NAME = "t2175-zemplar-repro";
+
+// Customer's exact settings from the support thread (Plain T-2175).
+const AUTO_TRANSCRIPTION_SETTINGS = {
+  language: "en",
+  model: "nova-3-medical",
+  profanity_filter: false,
+  endpointing: 500,
+  includeRawResponse: true,
+  extra: {
+    interim_results: true,
+    mip_opt_out: true,
+    numerals: false,
+  },
+};
+
+function getApiKey() {
+  if (process.env.DAILY_API_KEY) return process.env.DAILY_API_KEY;
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const env = readFileSync(join(repoRoot, ".env.local"), "utf8");
+  const match = env.match(/^VITE_DAILY_API_KEY="?([^"\n]+)"?$/m);
+  if (!match) throw new Error("VITE_DAILY_API_KEY not found in .env.local");
+  return match[1];
+}
+
+async function dailyApi(apiKey, method, path, body) {
+  const res = await fetch(`https://api.daily.co/v1${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json();
+  if (!res.ok) {
+    throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json)}`);
+  }
+  return json;
+}
+
+export async function createRoomAndToken() {
+  const apiKey = getApiKey();
+
+  const roomProps = {
+    enable_screenshare: true,
+    auto_transcription_settings: AUTO_TRANSCRIPTION_SETTINGS,
+    exp: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+  };
+
+  let room;
+  try {
+    room = await dailyApi(apiKey, "POST", "/rooms", {
+      name: ROOM_NAME,
+      properties: roomProps,
+    });
+  } catch (err) {
+    if (!String(err).includes("already exists")) throw err;
+    // Room exists from an earlier run: update its properties instead.
+    room = await dailyApi(apiKey, "POST", `/rooms/${ROOM_NAME}`, {
+      properties: roomProps,
+    });
+  }
+
+  // Customer's exact meeting token properties.
+  const token = await dailyApi(apiKey, "POST", "/meeting-tokens", {
+    properties: {
+      room_name: ROOM_NAME,
+      is_owner: true,
+      enable_live_captions_ui: true,
+      auto_start_transcription: true,
+      exp: Math.floor(Date.now() / 1000) + 2 * 60 * 60,
+    },
+  });
+
+  const appUrl = `http://localhost:3000/?zemplar=1&roomUrl=${encodeURIComponent(
+    room.url
+  )}&t=${encodeURIComponent(token.token)}`;
+
+  return { roomUrl: room.url, token: token.token, appUrl };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  createRoomAndToken()
+    .then((out) => console.log(JSON.stringify(out, null, 2)))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/src/ZemplarRepro.tsx
+++ b/src/ZemplarRepro.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Daily, { DailyCall, DailyEventObject } from "@daily-co/daily-js";
+
+// T-2175 zemplar repro page.
+//
+// Joins a room whose token has auto_start_transcription + enable_live_captions_ui
+// with the mic ON, then (on button click) starts a screen share that includes an
+// audio track. Every new audio track opens a fresh Deepgram websocket server-side,
+// which is the suspected trigger for the "zemplar" first-word hallucination.
+//
+// Every transcription event is logged to the console as a single line prefixed
+// with "T2175LOG " (JSON), collected in window.__t2175Log, and downloadable as
+// JSON via the button. Open with:
+//   /?zemplar=1&roomUrl=<encoded room url>&t=<meeting token>
+
+type LogEntry = Record<string, unknown> & { at: string; action: string };
+
+declare global {
+  interface Window {
+    __t2175Log: LogEntry[];
+  }
+}
+
+window.__t2175Log = window.__t2175Log ?? [];
+
+// Guard against React StrictMode double-mount (would double-register listeners).
+let initialized = false;
+
+function log(action: string, data: Record<string, unknown> = {}) {
+  const entry: LogEntry = { at: new Date().toISOString(), action, ...data };
+  window.__t2175Log.push(entry);
+  console.log(`T2175LOG ${JSON.stringify(entry)}`);
+}
+
+export default function ZemplarRepro() {
+  const callRef = useRef<DailyCall | null>(null);
+  const [status, setStatus] = useState("initializing");
+  const [captions, setCaptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    document.title = "T2175 Zemplar Repro";
+    const params = new URLSearchParams(window.location.search);
+    const roomUrl = params.get("roomUrl");
+    const token = params.get("t") ?? undefined;
+    if (!roomUrl) {
+      setStatus("missing ?roomUrl= param (run: node scripts/t2175-setup.mjs)");
+      return;
+    }
+
+    // Survive React StrictMode double-mount.
+    const call = Daily.getCallInstance() ?? Daily.createCallObject();
+    callRef.current = call;
+    if (initialized) return;
+    initialized = true;
+
+    const events = [
+      "joined-meeting",
+      "left-meeting",
+      "error",
+      "nonfatal-error",
+      "track-started",
+      "track-stopped",
+      "local-screen-share-started",
+      "local-screen-share-stopped",
+      "local-screen-share-canceled",
+      "transcription-started",
+      "transcription-stopped",
+      "transcription-error",
+    ] as const;
+
+    events.forEach((ev) =>
+      call.on(ev, (e: DailyEventObject) => {
+        // Track events: only log the bits we need (participant + track kind).
+        if (ev === "track-started" || ev === "track-stopped") {
+          const te = e as DailyEventObject<"track-started">;
+          log(ev, {
+            participantId: te.participant?.session_id,
+            trackKind: te.track?.kind,
+            trackType: te.type,
+          });
+        } else {
+          log(ev, { raw: e });
+        }
+      })
+    );
+
+    call.on("transcription-message", (e) => {
+      log("transcription-message", {
+        participantId: e.participantId,
+        trackType: e.trackType,
+        instanceId: e.instanceId,
+        text: e.text,
+        timestamp: e.timestamp,
+        rawResponse: e.rawResponse,
+      });
+      setCaptions((prev) => [
+        ...prev.slice(-30),
+        `[${e.trackType ?? "?"}] ${e.participantId?.slice(0, 8)}: ${e.text}`,
+      ]);
+    });
+
+    setStatus("joining");
+    call
+      .join({ url: roomUrl, token, startAudioOff: false, startVideoOff: true })
+      .then(() => {
+        setStatus("joined (mic on, waiting for transcription-started)");
+        log("join-resolved", { roomUrl });
+      })
+      .catch((err) => {
+        setStatus(`join failed: ${String(err)}`);
+        log("join-failed", { error: String(err) });
+      });
+
+    return () => {
+      // Intentionally do not destroy on unmount: StrictMode remounts.
+    };
+  }, []);
+
+  const startShare = useCallback(() => {
+    // audio: true so a NEW audio track (screen-audio) is created mid-call.
+    // selfBrowserSurface include so the headless runner can auto-pick this tab.
+    log("start-screen-share-clicked", {});
+    callRef.current?.startScreenShare({
+      displayMediaOptions: {
+        audio: true,
+        video: true,
+        selfBrowserSurface: "include",
+      },
+    });
+  }, []);
+
+  const downloadLog = useCallback(() => {
+    const blob = new Blob([JSON.stringify(window.__t2175Log, null, 2)], {
+      type: "application/json",
+    });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "t2175-transcription-log.json";
+    a.click();
+  }, []);
+
+  return (
+    <div style={{ fontFamily: "monospace", padding: 16 }}>
+      <h1>T-2175 zemplar repro</h1>
+      <div id="status">Status: {status}</div>
+      <p>
+        1. Wait for transcription-started in the console. 2. Click share (pick a
+        tab and check &quot;Also share tab audio&quot;). 3. Watch the first
+        caption on trackType screen-audio.
+      </p>
+      <button id="start-share" onClick={startShare}>
+        Start screen share (with audio)
+      </button>{" "}
+      <button id="download-log" onClick={downloadLog}>
+        Download JSON log
+      </button>
+      <h2>Captions</h2>
+      <div id="captions">
+        {captions.map((line, i) => (
+          <div key={i}>{line}</div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { Prebuilt } from "./Prebuilt";
 import { DailyProvider } from "@daily-co/daily-react";
 import App from "./App";
+import ZemplarRepro from "./ZemplarRepro";
 
 const container = document.getElementById("root");
 
@@ -15,10 +16,13 @@ const root = createRoot(container);
 // Get the value from the url
 const urlParams = new URLSearchParams(window.location.search);
 const isPrebuilt = urlParams.get("prebuilt") ?? false;
+const isZemplar = urlParams.get("zemplar") ?? false;
 
 root.render(
   <StrictMode>
-    {isPrebuilt ? (
+    {isZemplar ? (
+      <ZemplarRepro />
+    ) : isPrebuilt ? (
       <Prebuilt />
     ) : (
       <DailyProvider


### PR DESCRIPTION
## Summary
- Reproduces Deepgram nova-3-medical hallucinates the word "Zemplar" as the first caption on a brand new audio track, in a silent room.
- Uses the customer's exact room `auto_transcription_settings` (nova-3-medical, endpointing 500, includeRawResponse, mip_opt_out, etc.) and owner meeting token (`auto_start_transcription`, `enable_live_captions_ui`).
- Joins with mic on (silent fake mic), waits for transcription-started, then starts a tab screen share with audio so a second Deepgram websocket opens on the new `screen-audio` track.
- Logs every transcription/track event to console and a JSON file.

## Root cause
Every new audio track opens its own independent Deepgram websocket, and Daily forwards audio to it immediately with no VAD gate or warm-up buffer. The first packets into a fresh Deepgram connection appear to produce "Zemplar" deterministically for nova-3-medical.

## Result
Reproduced 3/3 automated runs, on both `cam-audio` (first caption after transcription starts) and `screen-audio` (first caption after starting screen share). Identical rawResponse each time: confidence 0.41685995, word start 0.64s, model medical-nova-3 v2025-09-30.18049. This is deterministic under total digital silence, which likely explains why the customer sees it only "occasionally" with a live mic (real noise floor varies the outcome).

## Files
- `scripts/t2175-setup.mjs` — creates/updates the Daily room + owner token with the customer's settings
- `src/ZemplarRepro.tsx` — repro page (`?zemplar=1`): join, log transcription/track events, screen-share button
- `scripts/t2175-run.mjs` — automated headed-Chromium run (silent fake mic, auto tab-share) via playwright-core

## Test plan
- [x] `node scripts/t2175-run.mjs` — ran 3x locally, "Zemplar" reproduced every time
- [x] `npx tsc --noEmit` passes
