### PR TITLE
Demo: knock-to-join without the built-in waiting room (app messages + permissions)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@daily-co/daily-js": "^0.91.0",
-        "@daily-co/daily-react": "^0.25.2",
+        "@daily-co/daily-react": "^0.25.3",
         "@vitejs/plugin-react-swc": "^3.7.2",
         "html2canvas": "^1.4.1",
         "jotai": "^2.12.5",
@@ -374,11 +374,12 @@
       }
     },
     "node_modules/@daily-co/daily-react": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-react/-/daily-react-0.25.2.tgz",
-      "integrity": "sha512-9evk6NiWEvIoEtjArHW4NHhN2JAldaHbzx4DHJtRGlAYUaYRhuCwQgZQlcc2e+xpMfkRMuHG45GarPnEwaUGXA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-react/-/daily-react-0.25.3.tgz",
+      "integrity": "sha512-rQrXpMFRAH68+iT2kWmOX+zYTZWKG7C+aGIASzo9lFexBl9ThQookHCNzkZFtOK6VQngs0LnbTgZfZWydG2v0w==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "jotai-family": "^1.0.2",
         "lodash.throttle": "^4.1.1"
       },
       "engines": {
@@ -4133,6 +4134,17 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jotai-family": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jotai-family/-/jotai-family-1.0.2.tgz",
+      "integrity": "sha512-U1aTMGxmsmz2Z8gaJD1/ljmMnsmG4/dqrcsfwGbjWV7p6boB9Vy3+75YwUpwPj7GbLNJk9O8rl1VNi8d7+6Rxw==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "jotai": ">=2.9.0"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.91.0",
-    "@daily-co/daily-react": "^0.25.2",
+    "@daily-co/daily-react": "^0.25.3",
     "@vitejs/plugin-react-swc": "^3.7.2",
     "html2canvas": "^1.4.1",
     "jotai": "^2.12.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useRef, useState } from "react";
 import Daily, {
   DailyEventObject,
+  DailyEventObjectAppMessage,
   DailyEventObjectParticipant,
 } from "@daily-co/daily-js";
 
 import {
   DailyAudio,
   DailyVideo,
+  useAppMessage,
   useAudioLevelObserver,
   useCPULoad,
   useDaily,
@@ -19,6 +21,7 @@ import {
   useNetwork,
   useParticipantCounts,
   useParticipantIds,
+  useParticipantProperty,
   useRecording,
   useScreenShare,
   useTranscription,
@@ -27,6 +30,14 @@ import {
 import "./styles.css";
 
 console.info("Daily version: %s", Daily.version());
+
+// Knock-to-join app messages. The patient broadcasts a "knock".
+// The owner replies with a targeted "knock-received" so the patient
+// knows the request landed.
+type KnockMessage =
+  | { type: "knock"; name: string }
+  | { type: "knock-received" }
+  | { type: "knock-denied" };
 console.info("Daily supported Browser:");
 console.dir(Daily.supportedBrowser());
 
@@ -70,8 +81,15 @@ export default function App() {
 
   const [enableBlurClicked, setEnableBlurClicked] = useState(false);
   const [enableBackgroundClicked, setEnableBackgroundClicked] = useState(false);
-  const [dailyRoomUrl, setDailyRoomUrl] = useState("");
-  const [dailyMeetingToken, setDailyMeetingToken] = useState("");
+  // Prefill the room url and token from the query string so the two
+  // sides of the knock demo are just two urls: one with ?t=OWNER_TOKEN
+  // (the owner) and one without (the patient).
+  const [dailyRoomUrl, setDailyRoomUrl] = useState(
+    () => new URLSearchParams(window.location.search).get("room") ?? ""
+  );
+  const [dailyMeetingToken, setDailyMeetingToken] = useState(
+    () => new URLSearchParams(window.location.search).get("t") ?? ""
+  );
 
   const {
     cameraError,
@@ -194,6 +212,94 @@ export default function App() {
   if (nonFatalError) {
     logEvent(nonFatalError);
   }
+
+  // --- Knock-to-join (waiting room without the built-in waiting room) ---
+  // The room is created with permissions { hasPresence: false,
+  // canSend: false, canReceive: { base: false } }, so tokenless joiners
+  // land hidden and locked. They knock with an app message. The owner
+  // admits with updateParticipant + updatePermissions, or denies with
+  // an eject. No backend involved.
+  const localSessionId = useLocalSessionId();
+  const isOwner = useParticipantProperty(localSessionId, "owner");
+  const localPermissions = useParticipantProperty(
+    localSessionId,
+    "permissions"
+  );
+
+  const [knockName, setKnockName] = useState("Patient");
+  const [knockStatus, setKnockStatus] = useState<
+    "idle" | "sent" | "seen" | "denied"
+  >("idle");
+  const [knocks, setKnocks] = useState<{ sessionId: string; name: string }[]>(
+    []
+  );
+
+  const sendAppMessage = useAppMessage<KnockMessage>({
+    onAppMessage: useCallback(
+      (ev: DailyEventObjectAppMessage<KnockMessage>) => {
+        logEvent(ev);
+        if (ev.data.type === "knock") {
+          const { name } = ev.data;
+          setKnocks((prev) =>
+            prev.some((k) => k.sessionId === ev.fromId)
+              ? prev
+              : [...prev, { sessionId: ev.fromId, name }]
+          );
+          // Targeted ack back to the hidden knocker so their UI can
+          // show the request was seen.
+          callObject?.sendAppMessage({ type: "knock-received" }, ev.fromId);
+        } else if (ev.data.type === "knock-received") {
+          setKnockStatus("seen");
+        } else if (ev.data.type === "knock-denied") {
+          setKnockStatus("denied");
+          // The lobby permissions are server-enforced either way, so a
+          // denied patient stays locked out even if they skip this leave.
+          callObject?.leave().catch((err) => {
+            console.error("Error leaving after deny", err);
+          });
+        }
+      },
+      [callObject, logEvent]
+    ),
+  });
+
+  const knock = useCallback(() => {
+    sendAppMessage({ type: "knock", name: knockName }, "*");
+    setKnockStatus("sent");
+    logEvent({ action: "knock-sent" });
+  }, [sendAppMessage, knockName, logEvent]);
+
+  const admitKnocker = useCallback(
+    (sessionId: string) => {
+      if (!callObject) return;
+      callObject.updateParticipant(sessionId, {
+        updatePermissions: {
+          hasPresence: true,
+          canSend: true,
+          canReceive: { base: true },
+        },
+      });
+      setKnocks((prev) => prev.filter((k) => k.sessionId !== sessionId));
+      logEvent({ action: "knock-admitted" });
+    },
+    [callObject, logEvent]
+  );
+
+  const denyKnocker = useCallback(
+    (sessionId: string) => {
+      if (!callObject) return;
+      // Tested empirically: updateParticipant(sessionId, { eject: true })
+      // is a silent no-op while the target is hidden (hasPresence false).
+      // Eject works fine once the participant is present. So deny is a
+      // targeted app message, and the patient leaves on its own.
+      callObject.sendAppMessage({ type: "knock-denied" }, sessionId);
+      setKnocks((prev) => prev.filter((k) => k.sessionId !== sessionId));
+      logEvent({ action: "knock-denied" });
+    },
+    [callObject, logEvent]
+  );
+
+  const isAdmitted = localPermissions?.hasPresence === true;
 
   const enableBlur = useCallback(() => {
     if (!callObject || enableBlurClicked) {
@@ -593,6 +699,52 @@ export default function App() {
         >
           Toggle Transcription
         </button>
+        <hr />
+        3. Knock to join (waiting room without the built-in waiting room)
+        <br />
+        {isOwner ? (
+          <div id="knockRequests">
+            Knock requests: {knocks.length === 0 && "none yet"}
+            {knocks.map((k) => (
+              <div key={k.sessionId}>
+                {k.name} ({k.sessionId}){" "}
+                <button onClick={() => admitKnocker(k.sessionId)}>
+                  Admit
+                </button>{" "}
+                <button onClick={() => denyKnocker(k.sessionId)}>Deny</button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div id="knockPanel">
+            <input
+              type="text"
+              value={knockName}
+              onChange={(event) => {
+                setKnockName(event.target.value);
+              }}
+            />
+            <button
+              disabled={meetingState !== "joined-meeting" || isAdmitted}
+              onClick={knock}
+            >
+              Knock
+            </button>
+            <div id="knockStatus">
+              {isAdmitted
+                ? "Admitted! You are in the call."
+                : knockStatus === "denied"
+                ? "The host denied your request."
+                : meetingState === "joined-meeting"
+                ? knockStatus === "seen"
+                  ? "The host saw your request. Hang tight."
+                  : knockStatus === "sent"
+                  ? "Knock sent. Waiting for the host."
+                  : "You are in the lobby. Knock to ask the host to let you in."
+                : "Join the room first, then knock."}
+            </div>
+          </div>
+        )}
       </div>
       {participantIds.map((id) => (
         <DailyVideo type="video" key={id} automirror sessionId={id} />


### PR DESCRIPTION
## Summary

A knock-to-join lobby with zero backend and no built-in waiting room. Useful when the room owner is on an SDK that has no waiting-room API, like [daily-client-ios](https://reference-ios.daily.co/documentation/daily/participantpermissionsupdate): `requestAccess()` and `updateWaitingParticipant()` do not exist there, but permissions updates do (`ParticipantPermissionsUpdate` covers `hasPresence`, `canSend`, and `canReceive`), so an iOS owner can run the admit side of this flow.

- The room is created with room-level `permissions: { hasPresence: false, canSend: false, canReceive: { base: false } }`, so every tokenless joiner lands hidden, unable to publish, and receiving nothing. This is server-enforced.
- The patient (no token) sees a lobby panel and knocks with `sendAppMessage({ type: "knock", name }, "*")` via the `useAppMessage` hook.
- The owner (joined with `?t=OWNER_TOKEN`) catches the knock in `useAppMessage`, sends a targeted `knock-received` ack back, and shows Admit / Deny buttons.
- Admit: `updateParticipant(sessionId, { updatePermissions: { hasPresence: true, canSend: true, canReceive: { base: true } } })`. The patient watches its own permissions through `useParticipantProperty(localSessionId, "permissions")` and flips from the lobby panel to the call.
- Deny: a targeted `knock-denied` app message, and the patient leaves on its own.
- Everything logs through the existing `logEvent` pattern, so the console doubles as an event-flow reference (`app-message`, `participant-updated`).

### Things we verified empirically (daily-js 0.91.0)

- A fully hidden and fully blind participant (`hasPresence: false`, `canSend: false`, `canReceive.base: false`) CAN broadcast app messages and CAN receive targeted app messages. The knock and the ack both work from inside the locked lobby.
- The REST API accepts `canReceive: { base: false }` in room-level `permissions` (object form with `base`, matching the daily-js type).
- `updateParticipant(sessionId, { eject: true })` is a silent no-op while the target is hidden: no error, no effect. Eject works normally once the participant is present. That is why Deny is an app message plus self-leave instead of an eject.

## Prerequisites

Create a room where everyone starts hidden and locked:

```bash
curl -s -X POST https://api.daily.co/v1/rooms \
  -H "Authorization: Bearer $DAILY_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"privacy":"public","properties":{"permissions":{"hasPresence":false,"canSend":false,"canReceive":{"base":false}}}}'
```

Mint one owner token for the host side:

```bash
curl -s -X POST https://api.daily.co/v1/meeting-tokens \
  -H "Authorization: Bearer $DAILY_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"properties":{"room_name":"ROOM_NAME","is_owner":true}}'
```

## Test plan

Ran with `npm run dev` and a room configured as above:

1. `npm test` (ESLint) and `npm run build` pass.
2. Tab A: `localhost:3000/?room=ROOM_URL&t=OWNER_TOKEN`, click Join call. Owner joins straight into the call with full permissions.
3. Tab B: `localhost:3000/?room=ROOM_URL` (no token), click Join call. Patient lands in the lobby: `hasPresence: false`, `canSend: false`, `canReceive.base: false`. Tab A shows Hidden Participants: 1 and the patient is absent from `participants()`.
4. Tab B clicks Knock. Tab A shows the request with Admit / Deny. Tab B status flips to "The host saw your request" (targeted ack received while hidden).
5. Tab A clicks Admit. Tab B permissions flip to `hasPresence: true`, `canSend: true`, `canReceive.base: true` and the lobby panel swaps to "Admitted!". Tab A now shows Present Participants: 2, Hidden: 0.
6. Repeat with Deny: Tab B shows "The host denied your request" and leaves the meeting (`left-meeting`).
7. Console `logEvent` output shows the expected `knock-sent`, `app-message`, and `participant-updated` sequence.
