### PR TITLE
Demo: hybrid presence + webhooks live roster

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env.local and fill in your Daily domain API key.
+# Find it at https://dashboard.daily.co/developers (domain owners only).
+# The key is used only by the Vite dev-server proxy (see vite.config.ts) to call
+# the Presence REST API. It is never bundled into the client. Keep it secret.
+DAILY_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,12 @@
-# Copy this file to .env.local and fill in your Daily domain API key.
-# Find it at https://dashboard.daily.co/developers (domain owners only).
-# The key is used only by the Vite dev-server proxy (see vite.config.ts) to call
-# the Presence REST API. It is never bundled into the client. Keep it secret.
+# Copy this file to .env.local and fill in the values.
+# .env.local is gitignored. These are read only by the backend (server/index.ts),
+# never by the browser.
+
+# Your Daily domain API key from https://dashboard.daily.co/developers
+# (domain owners only). Used to call the Presence REST API.
 DAILY_API_KEY=
+
+# The hmac secret returned when you register the webhook. Get it by running:
+#   node server/register-webhook.ts --url https://<ngrok>.ngrok.app/api/daily-webhook
+# Used to verify that incoming webhook POSTs really came from Daily.
+DAILY_WEBHOOK_HMAC=

--- a/README.md
+++ b/README.md
@@ -29,3 +29,34 @@ The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+## Presence API demo
+
+This branch adds a small panel that shows who is in your Daily rooms using the
+[`/presence` REST API](https://docs.daily.co/reference/rest-api/presence) instead
+of `participant.joined` / `participant.left` webhooks.
+
+It polls `/presence` every 15 seconds, lists the 10 most recently active rooms
+with their participants, and derives "joined" / "left" events by comparing each
+snapshot to the last one. That diff is the direct replacement for the two
+participant webhooks.
+
+The Presence API needs your domain API key, and that key must never be in browser
+code. So the request goes to `/api/presence`, which the Vite dev server proxies to
+`api.daily.co` with the `Authorization` header added server-side (see
+`vite.config.ts`). The key is never bundled into the client.
+
+### Setup
+
+1. Copy `.env.example` to `.env.local` and set `DAILY_API_KEY` to your domain key
+   from [dashboard.daily.co/developers](https://dashboard.daily.co/developers).
+   `.env.local` is gitignored.
+2. Run `npm run dev` and open [http://localhost:3000](http://localhost:3000).
+3. Join a room on that domain. Open the same room (or another room) in a second
+   tab or device.
+4. Within ~15 seconds the panel shows the rooms and their participants, and the
+   events feed logs a `joined` event. Leave in one tab and a `left` event appears.
+   The same events also print to the browser console.
+
+Note: this is a dev-server pattern. In production you would call `/presence` from
+your own backend.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ there is no build step for the backend.
    npm run dev:all
    ```
    (or run `npm run server` and `npm run dev` in two terminals). Open
-   [http://localhost:3000](http://localhost:3000). At this point the presence
-   snapshot and 10s reconcile already work.
+   [http://localhost:3000](http://localhost:3000). The presence + webhooks page
+   is the default route, so it loads straight away; the presence snapshot and 10s
+   reconcile already work. (The full kitchen-sink demo is at `?kitchensink=true`,
+   and Daily Prebuilt at `?prebuilt=true`.)
 3. Expose the backend so Daily can reach it, and register the webhook:
    ```
    ngrok http 4000

--- a/README.md
+++ b/README.md
@@ -30,33 +30,68 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-## Presence API demo
+## Presence + webhooks demo
 
-This branch adds a small panel that shows who is in your Daily rooms using the
-[`/presence` REST API](https://docs.daily.co/reference/rest-api/presence) instead
-of `participant.joined` / `participant.left` webhooks.
+This branch shows how to keep a live roster of who is in your Daily rooms using
+two sources together:
 
-It polls `/presence` every 15 seconds, lists the 10 most recently active rooms
-with their participants, and derives "joined" / "left" events by comparing each
-snapshot to the last one. That diff is the direct replacement for the two
-participant webhooks.
+- The [`/presence` REST API](https://docs.daily.co/reference/rest-api/presence)
+  for the snapshot on page load, plus a full reconcile every 10 seconds (the
+  authoritative safety net).
+- [Webhooks](https://docs.daily.co/reference/rest-api/webhooks) (`participant.joined`
+  and `participant.left`) for the fast "in between" updates, pushed to the browser
+  over a WebSocket so the roster changes within a second or two instead of waiting
+  for the next poll.
 
-The Presence API needs your domain API key, and that key must never be in browser
-code. So the request goes to `/api/presence`, which the Vite dev server proxies to
-`api.daily.co` with the `Authorization` header added server-side (see
-`vite.config.ts`). The key is never bundled into the client.
+Presence gives correctness; webhooks give speed. The panel tags each event with
+its source (`webhook` or `presence`) so you can see the difference.
+
+### How it fits together
+
+```
+Browser (PresencePanel)
+  GET /api/presence   -> snapshot on load + reconcile every 10s
+  WebSocket /ws       <- live joined/left pushed by the server
+        |
+Vite dev server  -- proxies /api and /ws -->  Node server (server/index.ts)
+                                                holds DAILY_API_KEY, calls /presence
+                                                POST /api/daily-webhook  <- Daily (via ngrok)
+                                                verifies the hmac, 200 fast, broadcasts on /ws
+```
+
+The domain API key and the webhook hmac live only on the server. The browser
+never talks to `api.daily.co` and never sees a secret.
+
+The server files are TypeScript run directly by Node (v24+ strips types), so
+there is no build step for the backend.
 
 ### Setup
 
 1. Copy `.env.example` to `.env.local` and set `DAILY_API_KEY` to your domain key
    from [dashboard.daily.co/developers](https://dashboard.daily.co/developers).
    `.env.local` is gitignored.
-2. Run `npm run dev` and open [http://localhost:3000](http://localhost:3000).
-3. Join a room on that domain. Open the same room (or another room) in a second
-   tab or device.
-4. Within ~15 seconds the panel shows the rooms and their participants, and the
-   events feed logs a `joined` event. Leave in one tab and a `left` event appears.
-   The same events also print to the browser console.
+2. Start the app and the backend together:
+   ```
+   npm run dev:all
+   ```
+   (or run `npm run server` and `npm run dev` in two terminals). Open
+   [http://localhost:3000](http://localhost:3000). At this point the presence
+   snapshot and 10s reconcile already work.
+3. Expose the backend so Daily can reach it, and register the webhook:
+   ```
+   ngrok http 4000
+   node server/register-webhook.ts --url https://<your-ngrok>.ngrok.app/api/daily-webhook
+   ```
+   Copy the `hmac` it prints into `.env.local` as `DAILY_WEBHOOK_HMAC`, then
+   restart the server.
+4. Join a room on your domain, then join the same room in a second tab. The roster
+   updates within a second or two from a `webhook` event, and the 10s reconcile
+   confirms it. Leave in one tab and a `left` event appears just as fast.
+5. Clean up when done (webhooks are domain-wide and persist):
+   ```
+   node server/register-webhook.ts --list
+   node server/register-webhook.ts --delete <uuid>
+   ```
 
-Note: this is a dev-server pattern. In production you would call `/presence` from
-your own backend.
+Note: this is a local dev setup (ngrok tunnel + Vite proxy). In production you
+would run the receiver and WebSocket on your own backend.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,16 +11,22 @@
         "@daily-co/daily-js": "^0.91.0",
         "@daily-co/daily-react": "^0.25.2",
         "@vitejs/plugin-react-swc": "^3.7.2",
+        "dotenv": "^17.4.2",
+        "express": "^5.2.1",
         "html2canvas": "^1.4.1",
         "jotai": "^2.12.5",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "ws": "^8.21.1"
       },
       "devDependencies": {
         "@tsconfig/vite-react": "^3.0.2",
-        "@types/node": "^18.11.18",
+        "@types/express": "^5.0.6",
+        "@types/node": "^24.13.3",
         "@types/react": "^19.1.3",
         "@types/react-dom": "^19.1.3",
+        "@types/ws": "^8.18.1",
+        "concurrently": "^10.0.3",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.2",
@@ -1777,6 +1783,27 @@
       "integrity": "sha512-AFynAtE1Un3Rko20Ghe2mVC/QWD4rStJ2PnyIZU2kzC4UyWpf1YhAEY87GojH/XPZCY8Mdt27gsYyy+6l6HV+w==",
       "dev": true
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.5.tgz",
@@ -1792,6 +1819,38 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1799,13 +1858,28 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.23.tgz",
-      "integrity": "sha512-wtE3d0OUfNKtZYAqZb8HAWGxxXsImJcPUAgZNw+dWFxO6s5tIwIjyKnY76tsTatsNCLJPkVYwUpq15D38ng9Aw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.3",
@@ -1823,6 +1897,37 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2080,6 +2185,44 @@
         "vite": "^4 || ^5 || ^6"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -2335,6 +2478,43 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -2394,6 +2574,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -2405,6 +2594,35 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2468,6 +2686,50 @@
         "node": ">=4"
       }
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2501,11 +2763,102 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concurrently": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
+      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
+        "tree-kill": "1.2.2",
+        "yargs": "18.0.0"
+      },
+      "bin": {
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2587,12 +2940,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2652,6 +3005,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -2688,17 +3050,59 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/dot-case/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.701",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.701.tgz",
       "integrity": "sha512-K3WPQ36bUOtXg/1+69bFlFOvdSm0/0bGqmsfPDLRXLanoKXdA+pIWuf/VbA9b+2CwBFuONgl4NEz4OEm+OJOKA==",
       "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -2782,13 +3186,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2797,7 +3198,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2828,10 +3228,10 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-      "dev": true,
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2924,6 +3324,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -3235,12 +3641,89 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3319,6 +3802,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3400,6 +3904,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3423,7 +3945,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3464,23 +3985,64 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-symbol-description": {
@@ -3564,12 +4126,12 @@
       "dev": true
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3624,10 +4186,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3654,7 +4216,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3672,6 +4233,42 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -3721,8 +4318,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -3736,6 +4332,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3961,6 +4566,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -4291,12 +4902,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/lower-case/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4304,6 +4909,36 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -4362,10 +4997,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -4390,6 +5025,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -4399,12 +5043,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/no-case/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/node-releases": {
       "version": "2.0.14",
@@ -4422,10 +5060,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4523,11 +5164,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -4609,6 +5261,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4641,6 +5302,16 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -4724,6 +5395,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4737,6 +5421,22 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -4758,6 +5458,34 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "19.1.1",
@@ -4910,6 +5638,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4931,6 +5675,16 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -4968,6 +5722,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -4980,6 +5740,76 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -5014,6 +5844,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5035,16 +5871,83 @@
         "node": ">=8"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5063,18 +5966,68 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/snake-case/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -5241,6 +6194,25 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -5273,6 +6245,13 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5295,6 +6274,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -5425,16 +6460,26 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
       "dev": true
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -5481,6 +6526,15 @@
       "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -5734,17 +6788,135 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,16 +11,24 @@
     "@daily-co/daily-js": "^0.91.0",
     "@daily-co/daily-react": "^0.25.2",
     "@vitejs/plugin-react-swc": "^3.7.2",
+    "dotenv": "^17.4.2",
+    "express": "^5.2.1",
     "html2canvas": "^1.4.1",
     "jotai": "^2.12.5",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "ws": "^8.21.1"
   },
   "scripts": {
     "dev": "vite --host",
+    "server": "node server/index.ts",
+    "dev:all": "concurrently -n vite,server -c cyan,green \"npm run dev\" \"npm run server\"",
+    "register-webhook": "node server/register-webhook.ts",
     "build": "tsc && vite build",
     "serve": "vite preview",
-    "test": "eslint src/"
+    "test": "eslint src/",
+    "typecheck:server": "tsc -p server/tsconfig.json",
+    "test:server": "node --test \"server/**/*.test.ts\""
   },
   "browserslist": {
     "production": [
@@ -36,9 +44,12 @@
   },
   "devDependencies": {
     "@tsconfig/vite-react": "^3.0.2",
-    "@types/node": "^18.11.18",
+    "@types/express": "^5.0.6",
+    "@types/node": "^24.13.3",
     "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",
+    "@types/ws": "^8.18.1",
+    "concurrently": "^10.0.3",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.2",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,130 @@
+import http from "node:http";
+import express from "express";
+import type { Request, Response } from "express";
+import { WebSocketServer, WebSocket } from "ws";
+import dotenv from "dotenv";
+import { verifySignature } from "./verifySignature.ts";
+
+// Load env from .env.local first (real secrets, gitignored), then .env.
+dotenv.config({ path: [".env.local", ".env"] });
+
+const DAILY_API_KEY = process.env.DAILY_API_KEY;
+const DAILY_WEBHOOK_HMAC = process.env.DAILY_WEBHOOK_HMAC;
+const PORT = Number(process.env.PORT ?? 4000);
+
+if (!DAILY_API_KEY) {
+  console.warn("[server] DAILY_API_KEY is not set. /api/presence will fail.");
+}
+if (!DAILY_WEBHOOK_HMAC) {
+  console.warn(
+    "[server] DAILY_WEBHOOK_HMAC is not set. Webhook events will be rejected until you register a webhook and set it.",
+  );
+}
+
+// The message we push to browsers over the WebSocket for each participant event.
+interface RosterMessage {
+  type: "participant.joined" | "participant.left";
+  room: string;
+  session_id: string;
+  user_name: string;
+  joined_at: number;
+  duration?: number;
+  event_ts?: number;
+}
+
+const app = express();
+app.use(express.json());
+
+// Presence snapshot. The domain API key stays here on the server; the browser
+// only ever calls /api/presence.
+app.get("/api/presence", async (_req: Request, res: Response) => {
+  if (!DAILY_API_KEY) {
+    res.status(500).json({ error: "DAILY_API_KEY not set on the server" });
+    return;
+  }
+  try {
+    const r = await fetch("https://api.daily.co/v1/presence", {
+      headers: { Authorization: `Bearer ${DAILY_API_KEY}` },
+    });
+    const data: unknown = await r.json();
+    res.status(r.status).json(data);
+  } catch (err) {
+    res.status(502).json({ error: `Presence fetch failed: ${String(err)}` });
+  }
+});
+
+// Daily webhook receiver.
+app.post("/api/daily-webhook", (req: Request, res: Response) => {
+  const body: unknown = req.body;
+
+  // Create-time handshake: Daily POSTs {"test":"test"} and expects a fast 200.
+  if (
+    body !== null &&
+    typeof body === "object" &&
+    (body as { test?: unknown }).test === "test"
+  ) {
+    res.sendStatus(200);
+    return;
+  }
+
+  const timestamp = req.header("X-Webhook-Timestamp");
+  const signature = req.header("X-Webhook-Signature");
+  if (
+    !DAILY_WEBHOOK_HMAC ||
+    !timestamp ||
+    !signature ||
+    !verifySignature(timestamp, body, DAILY_WEBHOOK_HMAC, signature)
+  ) {
+    res.sendStatus(401);
+    return;
+  }
+
+  // Respond fast (the circuit breaker trips after 3 slow/failed responses), then
+  // fan the event out to connected browsers.
+  res.sendStatus(200);
+
+  const event = body as {
+    type?: string;
+    event_ts?: number;
+    payload?: {
+      room?: string;
+      session_id?: string;
+      user_name?: string;
+      joined_at?: number;
+      duration?: number;
+    };
+  };
+
+  if (event.type !== "participant.joined" && event.type !== "participant.left") {
+    return;
+  }
+  const p = event.payload ?? {};
+  broadcast({
+    type: event.type,
+    room: p.room ?? "",
+    session_id: p.session_id ?? "",
+    user_name: p.user_name ?? "",
+    joined_at: p.joined_at ?? 0,
+    duration: p.duration,
+    event_ts: event.event_ts,
+  });
+});
+
+const server = http.createServer(app);
+const wss = new WebSocketServer({ server, path: "/ws" });
+
+function broadcast(message: RosterMessage): void {
+  const data = JSON.stringify(message);
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(data);
+    }
+  }
+}
+
+server.listen(PORT, () => {
+  console.log(`[server] listening on http://localhost:${PORT}`);
+  console.log(`[server]   GET  /api/presence`);
+  console.log(`[server]   POST /api/daily-webhook`);
+  console.log(`[server]   WS   /ws`);
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,8 +32,21 @@ interface RosterMessage {
   event_ts?: number;
 }
 
+// Express Request with the raw body buffer captured for signature verification.
+interface RawBodyRequest extends Request {
+  rawBody?: Buffer;
+}
+
 const app = express();
-app.use(express.json());
+// Capture the raw body so we verify the webhook signature against the exact
+// bytes Daily signed, not a re-serialized object.
+app.use(
+  express.json({
+    verify: (req, _res, buf) => {
+      (req as RawBodyRequest).rawBody = buf;
+    },
+  }),
+);
 
 // Presence snapshot. The domain API key stays here on the server; the browser
 // only ever calls /api/presence.
@@ -69,11 +82,12 @@ app.post("/api/daily-webhook", (req: Request, res: Response) => {
 
   const timestamp = req.header("X-Webhook-Timestamp");
   const signature = req.header("X-Webhook-Signature");
+  const rawBody = (req as RawBodyRequest).rawBody?.toString("utf8") ?? "";
   if (
     !DAILY_WEBHOOK_HMAC ||
     !timestamp ||
     !signature ||
-    !verifySignature(timestamp, body, DAILY_WEBHOOK_HMAC, signature)
+    !verifySignature(timestamp, rawBody, DAILY_WEBHOOK_HMAC, signature)
   ) {
     res.sendStatus(401);
     return;

--- a/server/register-webhook.ts
+++ b/server/register-webhook.ts
@@ -1,0 +1,124 @@
+import dotenv from "dotenv";
+
+// Load env from .env.local first, then .env.
+dotenv.config({ path: [".env.local", ".env"] });
+
+const API = "https://api.daily.co/v1/webhooks";
+const DAILY_API_KEY = process.env.DAILY_API_KEY;
+
+const EVENT_TYPES = ["participant.joined", "participant.left"];
+
+function authHeaders(): Record<string, string> {
+  if (!DAILY_API_KEY) {
+    console.error("DAILY_API_KEY is not set (put it in .env.local).");
+    process.exit(1);
+  }
+  return {
+    Authorization: `Bearer ${DAILY_API_KEY}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function getArg(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+
+function printHmacNextSteps(data: { uuid?: string; hmac?: string }): void {
+  console.log(`  uuid: ${data.uuid ?? "(none)"}`);
+  console.log(`  hmac: ${data.hmac ?? "(none)"}`);
+  console.log("");
+  console.log("Next: add this line to .env.local, then restart the server:");
+  console.log(`  DAILY_WEBHOOK_HMAC=${data.hmac ?? ""}`);
+}
+
+async function create(url: string): Promise<void> {
+  const res = await fetch(API, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ url, eventTypes: EVENT_TYPES }),
+  });
+  const data: unknown = await res.json();
+  if (!res.ok) {
+    // Daily allows only one webhook per domain. If one already exists, point the
+    // caller at --list / --update instead of failing silently.
+    const err = data as { info?: string };
+    if (res.status === 400 && err.info?.includes("only 1 webhook")) {
+      console.error("A webhook already exists for this domain.");
+      console.error("Run `--list` to see it, then `--update <uuid>` to repoint");
+      console.error("it at your URL, or `--delete <uuid>` to remove it.");
+      process.exit(1);
+    }
+    console.error(`Create failed (HTTP ${res.status}):`, data);
+    process.exit(1);
+  }
+  console.log("Webhook created.");
+  printHmacNextSteps(data as { uuid?: string; hmac?: string });
+}
+
+async function update(uuid: string, url: string): Promise<void> {
+  const res = await fetch(`${API}/${uuid}`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ url, eventTypes: EVENT_TYPES }),
+  });
+  const data: unknown = await res.json();
+  if (!res.ok) {
+    console.error(`Update failed (HTTP ${res.status}):`, data);
+    process.exit(1);
+  }
+  console.log(`Webhook ${uuid} updated.`);
+  printHmacNextSteps(data as { uuid?: string; hmac?: string });
+}
+
+async function list(): Promise<void> {
+  const res = await fetch(API, { headers: authHeaders() });
+  const data: unknown = await res.json();
+  console.log(JSON.stringify(data, null, 2));
+}
+
+async function remove(uuid: string): Promise<void> {
+  const res = await fetch(`${API}/${uuid}`, {
+    method: "DELETE",
+    headers: authHeaders(),
+  });
+  const data: unknown = await res.json();
+  if (!res.ok) {
+    console.error(`Delete failed (HTTP ${res.status}):`, data);
+    process.exit(1);
+  }
+  console.log(`Deleted webhook ${uuid}.`);
+}
+
+async function main(): Promise<void> {
+  const url = getArg("--url");
+  const del = getArg("--delete");
+  const upd = getArg("--update");
+
+  if (process.argv.includes("--list")) {
+    await list();
+  } else if (del) {
+    await remove(del);
+  } else if (upd) {
+    if (!url) {
+      console.error("--update <uuid> also needs --url <endpoint>.");
+      process.exit(1);
+    }
+    await update(upd, url);
+  } else if (url) {
+    await create(url);
+  } else {
+    console.log("Usage:");
+    console.log(
+      "  node server/register-webhook.ts --url https://<ngrok>.ngrok.app/api/daily-webhook",
+    );
+    console.log(
+      "  node server/register-webhook.ts --update <uuid> --url https://<ngrok>.ngrok.app/api/daily-webhook",
+    );
+    console.log("  node server/register-webhook.ts --list");
+    console.log("  node server/register-webhook.ts --delete <uuid>");
+    process.exit(1);
+  }
+}
+
+void main();

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["."]
+}

--- a/server/verifySignature.test.ts
+++ b/server/verifySignature.test.ts
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { verifySignature } from "./verifySignature.ts";
+
+// Sign a body the same way Daily does, so we can prove verifySignature accepts a
+// valid signature and rejects tampered ones. (The live end-to-end test against a
+// real Daily webhook is the byte-for-byte proof; this locks the algorithm.)
+const secret = Buffer.from("super-secret-value").toString("base64");
+const timestamp = "1708972279";
+const body = {
+  version: "1.0.0",
+  type: "participant.joined",
+  payload: { room: "test", session_id: "abc", user_name: "sam" },
+  event_ts: 1708972279.961,
+};
+
+function sign(ts: string, b: unknown, base64Secret: string): string {
+  return crypto
+    .createHmac("sha256", Buffer.from(base64Secret, "base64"))
+    .update(`${ts}.${JSON.stringify(b)}`)
+    .digest("base64");
+}
+
+test("accepts a valid signature", () => {
+  const sig = sign(timestamp, body, secret);
+  assert.equal(verifySignature(timestamp, body, secret, sig), true);
+});
+
+test("rejects a tampered body", () => {
+  const sig = sign(timestamp, body, secret);
+  const tampered = { ...body, payload: { ...body.payload, user_name: "eve" } };
+  assert.equal(verifySignature(timestamp, tampered, secret, sig), false);
+});
+
+test("rejects a wrong timestamp", () => {
+  const sig = sign(timestamp, body, secret);
+  assert.equal(verifySignature("0", body, secret, sig), false);
+});
+
+test("rejects a wrong secret", () => {
+  const sig = sign(timestamp, body, secret);
+  const otherSecret = Buffer.from("different").toString("base64");
+  assert.equal(verifySignature(timestamp, body, otherSecret, sig), false);
+});

--- a/server/verifySignature.test.ts
+++ b/server/verifySignature.test.ts
@@ -3,43 +3,44 @@ import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import { verifySignature } from "./verifySignature.ts";
 
-// Sign a body the same way Daily does, so we can prove verifySignature accepts a
-// valid signature and rejects tampered ones. (The live end-to-end test against a
-// real Daily webhook is the byte-for-byte proof; this locks the algorithm.)
+// Sign a raw body the same way Daily does, so we can prove verifySignature
+// accepts a valid signature and rejects tampered ones. (The live end-to-end test
+// against a real Daily webhook is the byte-for-byte proof; this locks the
+// algorithm.)
 const secret = Buffer.from("super-secret-value").toString("base64");
 const timestamp = "1708972279";
-const body = {
+const rawBody = JSON.stringify({
   version: "1.0.0",
   type: "participant.joined",
   payload: { room: "test", session_id: "abc", user_name: "sam" },
   event_ts: 1708972279.961,
-};
+});
 
-function sign(ts: string, b: unknown, base64Secret: string): string {
+function sign(ts: string, body: string, base64Secret: string): string {
   return crypto
     .createHmac("sha256", Buffer.from(base64Secret, "base64"))
-    .update(`${ts}.${JSON.stringify(b)}`)
+    .update(`${ts}.${body}`)
     .digest("base64");
 }
 
 test("accepts a valid signature", () => {
-  const sig = sign(timestamp, body, secret);
-  assert.equal(verifySignature(timestamp, body, secret, sig), true);
+  const sig = sign(timestamp, rawBody, secret);
+  assert.equal(verifySignature(timestamp, rawBody, secret, sig), true);
 });
 
 test("rejects a tampered body", () => {
-  const sig = sign(timestamp, body, secret);
-  const tampered = { ...body, payload: { ...body.payload, user_name: "eve" } };
+  const sig = sign(timestamp, rawBody, secret);
+  const tampered = rawBody.replace("sam", "eve");
   assert.equal(verifySignature(timestamp, tampered, secret, sig), false);
 });
 
 test("rejects a wrong timestamp", () => {
-  const sig = sign(timestamp, body, secret);
-  assert.equal(verifySignature("0", body, secret, sig), false);
+  const sig = sign(timestamp, rawBody, secret);
+  assert.equal(verifySignature("0", rawBody, secret, sig), false);
 });
 
 test("rejects a wrong secret", () => {
-  const sig = sign(timestamp, body, secret);
+  const sig = sign(timestamp, rawBody, secret);
   const otherSecret = Buffer.from("different").toString("base64");
-  assert.equal(verifySignature(timestamp, body, otherSecret, sig), false);
+  assert.equal(verifySignature(timestamp, rawBody, otherSecret, sig), false);
 });

--- a/server/verifySignature.ts
+++ b/server/verifySignature.ts
@@ -1,0 +1,31 @@
+import crypto from "node:crypto";
+
+/**
+ * Verify a Daily webhook signature.
+ *
+ * Daily sends two headers with each event POST: X-Webhook-Timestamp and
+ * X-Webhook-Signature. The signature is an HMAC-SHA256, base64-encoded, computed
+ * over `timestamp + "." + JSON.stringify(body)` using the base64-decoded hmac
+ * secret that /webhooks returned when the webhook was created.
+ *
+ * See https://docs.daily.co/reference/rest-api/webhooks#webhook-structure
+ */
+export function verifySignature(
+  timestamp: string,
+  body: unknown,
+  base64Secret: string,
+  providedSignature: string,
+): boolean {
+  const signedContent = `${timestamp}.${JSON.stringify(body)}`;
+  const secret = Buffer.from(base64Secret, "base64");
+  const computed = crypto
+    .createHmac("sha256", secret)
+    .update(signedContent)
+    .digest("base64");
+
+  const a = Buffer.from(computed);
+  const b = Buffer.from(providedSignature);
+  // timingSafeEqual throws on length mismatch, so guard first.
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}

--- a/server/verifySignature.ts
+++ b/server/verifySignature.ts
@@ -5,18 +5,22 @@ import crypto from "node:crypto";
  *
  * Daily sends two headers with each event POST: X-Webhook-Timestamp and
  * X-Webhook-Signature. The signature is an HMAC-SHA256, base64-encoded, computed
- * over `timestamp + "." + JSON.stringify(body)` using the base64-decoded hmac
+ * over `timestamp + "." + <raw request body>` using the base64-decoded hmac
  * secret that /webhooks returned when the webhook was created.
+ *
+ * Verify against the RAW request body bytes, not a re-serialized object: parsing
+ * and re-stringifying can change number formatting or key order and silently
+ * break verification.
  *
  * See https://docs.daily.co/reference/rest-api/webhooks#webhook-structure
  */
 export function verifySignature(
   timestamp: string,
-  body: unknown,
+  rawBody: string,
   base64Secret: string,
   providedSignature: string,
 ): boolean {
-  const signedContent = `${timestamp}.${JSON.stringify(body)}`;
+  const signedContent = `${timestamp}.${rawBody}`;
   const secret = Buffer.from(base64Secret, "base64");
   const computed = crypto
     .createHmac("sha256", secret)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ import {
   useTranscription,
 } from "@daily-co/daily-react";
 
+import { PresencePanel } from "./PresencePanel";
+
 import "./styles.css";
 
 console.info("Daily version: %s", Daily.version());
@@ -625,6 +627,7 @@ export default function App() {
       <div>
         CPU load: {cpuLoad.state} {cpuLoad.reason}
       </div>
+      <PresencePanel />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,8 +24,6 @@ import {
   useTranscription,
 } from "@daily-co/daily-react";
 
-import { PresencePanel } from "./PresencePanel";
-
 import "./styles.css";
 
 console.info("Daily version: %s", Daily.version());
@@ -627,7 +625,6 @@ export default function App() {
       <div>
         CPU load: {cpuLoad.state} {cpuLoad.reason}
       </div>
-      <PresencePanel />
     </>
   );
 }

--- a/src/PresencePage.tsx
+++ b/src/PresencePage.tsx
@@ -1,0 +1,29 @@
+import { type ReactElement } from "react";
+import { PresencePanel } from "./PresencePanel";
+
+/**
+ * Standalone page for the presence + webhooks demo. PresencePanel talks to the
+ * backend over fetch and a WebSocket and uses no daily-react hooks, so this page
+ * needs no DailyProvider.
+ */
+export function PresencePage(): ReactElement {
+  return (
+    <div
+      style={{
+        maxWidth: 680,
+        margin: "24px auto",
+        padding: "0 16px",
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      <h1>Daily presence + webhooks</h1>
+      <p style={{ color: "#555" }}>
+        A live room roster built from the Presence API snapshot (reconciled every
+        10s) plus participant.joined / participant.left webhooks pushed over a
+        WebSocket. See the README for the backend and ngrok setup. The full
+        kitchen-sink demo is at <code>?kitchensink=true</code>.
+      </p>
+      <PresencePanel />
+    </div>
+  );
+}

--- a/src/PresencePanel.tsx
+++ b/src/PresencePanel.tsx
@@ -237,7 +237,7 @@ export function PresencePanel(): ReactElement {
           };
         });
         pushEvent("webhook", "joined", msg.room, msg.user_name);
-      } else {
+      } else if (msg.type === "participant.left") {
         recentlyLeftRef.current.set(key, nowMs);
         setRoster((prev) => {
           const list = prev[msg.room];

--- a/src/PresencePanel.tsx
+++ b/src/PresencePanel.tsx
@@ -1,0 +1,257 @@
+import { type ReactElement, useCallback, useEffect, useRef, useState } from "react";
+
+// Poll no more than once every 15s (per the Presence API docs); data can lag up
+// to 15s behind reality.
+const POLL_INTERVAL_MS = 15_000;
+const MAX_ROOMS = 10;
+const MAX_FEED = 50;
+
+// One participant as returned by GET /presence.
+interface PresenceParticipant {
+  room: string;
+  id: string;
+  userId: string | null;
+  userName: string;
+  mtgSessionId: string;
+  joinTime: string;
+  duration: number;
+}
+
+// GET /presence returns a map of room name -> currently present participants.
+type PresenceResponse = Record<string, PresenceParticipant[]>;
+
+interface PresenceRoom {
+  room: string;
+  participants: PresenceParticipant[];
+  latestJoin: number;
+}
+
+type PresenceEventType = "joined" | "left";
+
+interface DerivedEvent {
+  key: string;
+  type: PresenceEventType;
+  room: string;
+  userName: string;
+  at: string;
+}
+
+// A stable key for one participant in one room, so the same id in two rooms is
+// treated as two distinct people.
+function participantKey(p: PresenceParticipant): string {
+  return `${p.room}:${p.id}`;
+}
+
+/**
+ * Presence API demo.
+ *
+ * Instead of consuming participant.joined / participant.left webhooks, this
+ * polls the /presence REST endpoint every 15s, renders a live roster of the 10
+ * most recently active rooms, and derives synthetic "joined" / "left" events by
+ * diffing each snapshot against the previous one. That diff is the direct
+ * replacement for the two webhooks.
+ *
+ * The domain API key is never in the browser: the request goes to /api/presence,
+ * which the Vite dev server proxies to api.daily.co with the Authorization
+ * header added server-side (see vite.config.ts).
+ */
+export function PresencePanel(): ReactElement {
+  const [rooms, setRooms] = useState<PresenceRoom[]>([]);
+  const [events, setEvents] = useState<DerivedEvent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Previous snapshot, keyed by `${room}:${id}`, used to diff for join/left.
+  const prevRef = useRef<Map<string, PresenceParticipant>>(new Map());
+  // Skip event generation on the first successful poll: we only report changes
+  // that happen after we start listening, the same as a webhook consumer would.
+  const seededRef = useRef(false);
+
+  const fetchPresence = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/presence", {
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!res.ok) {
+        if (res.status === 401 || res.status === 400) {
+          setError(
+            "Auth failed (check DAILY_API_KEY in .env.local, then restart the dev server).",
+          );
+        } else if (res.status === 429) {
+          setError("Rate limited by the Presence API. Polling will retry.");
+        } else {
+          setError(`Presence request failed: HTTP ${res.status}.`);
+        }
+        return;
+      }
+
+      const data = (await res.json()) as PresenceResponse;
+
+      // Flatten the current snapshot into a keyed map.
+      const currentMap = new Map<string, PresenceParticipant>();
+      for (const participants of Object.values(data)) {
+        for (const p of participants) {
+          currentMap.set(participantKey(p), p);
+        }
+      }
+
+      // Diff against the previous snapshot to derive joined/left events.
+      if (seededRef.current) {
+        const now = new Date().toISOString();
+        const newEvents: DerivedEvent[] = [];
+
+        for (const [key, p] of currentMap) {
+          if (!prevRef.current.has(key)) {
+            console.log("presence: joined", { room: p.room, participant: p });
+            newEvents.push({
+              key: `${key}:joined:${now}`,
+              type: "joined",
+              room: p.room,
+              userName: p.userName,
+              at: now,
+            });
+          }
+        }
+        for (const [key, p] of prevRef.current) {
+          if (!currentMap.has(key)) {
+            console.log("presence: left", { room: p.room, participant: p });
+            newEvents.push({
+              key: `${key}:left:${now}`,
+              type: "left",
+              room: p.room,
+              userName: p.userName,
+              at: now,
+            });
+          }
+        }
+
+        if (newEvents.length > 0) {
+          setEvents((prev) => [...newEvents, ...prev].slice(0, MAX_FEED));
+        }
+      } else {
+        seededRef.current = true;
+      }
+
+      prevRef.current = currentMap;
+
+      // Rank rooms by their most recent participant joinTime, keep the top 10.
+      const rankedRooms: PresenceRoom[] = Object.entries(data)
+        .map(([room, participants]) => ({
+          room,
+          participants,
+          latestJoin: participants.reduce(
+            (max, p) => Math.max(max, new Date(p.joinTime).getTime()),
+            0,
+          ),
+        }))
+        .sort((a, b) => b.latestJoin - a.latestJoin)
+        .slice(0, MAX_ROOMS);
+
+      setRooms(rankedRooms);
+      setLastUpdated(new Date().toLocaleTimeString());
+      setError(null);
+    } catch (err) {
+      setError(
+        `Could not reach the Presence proxy: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPresence();
+    const interval = setInterval(() => void fetchPresence(), POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchPresence]);
+
+  return (
+    <div
+      id="presencePanel"
+      style={{
+        border: "1px solid #ccc",
+        borderRadius: 8,
+        padding: 12,
+        marginTop: 16,
+        maxWidth: 600,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <strong>Presence API: {MAX_ROOMS} most recent rooms</strong>
+        <button type="button" onClick={() => void fetchPresence()}>
+          Refresh presence
+        </button>
+      </div>
+
+      <div style={{ fontSize: 12, color: "#666", marginTop: 4 }}>
+        Polls /api/presence every 15s. Last updated: {lastUpdated ?? "never"}
+        {loading ? " (refreshing…)" : ""}
+      </div>
+
+      {error && (
+        <div id="presenceError" style={{ color: "#b00", marginTop: 8 }}>
+          {error}
+        </div>
+      )}
+
+      <h4 style={{ marginBottom: 4 }}>Rooms</h4>
+      {rooms.length === 0 ? (
+        <div style={{ color: "#666" }}>
+          No active rooms on this domain yet. Join a room to see presence here.
+        </div>
+      ) : (
+        rooms.map((r) => (
+          <div key={r.room} style={{ marginBottom: 8 }}>
+            <div>
+              <strong>{r.room}</strong> ({r.participants.length})
+            </div>
+            <ul style={{ margin: "4px 0", paddingLeft: 20 }}>
+              {r.participants.map((p) => (
+                <li key={p.id}>
+                  {p.userName || "(no name)"} : {p.id} : joined{" "}
+                  {new Date(p.joinTime).toLocaleTimeString()} : {p.duration}s
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))
+      )}
+
+      <h4 style={{ marginBottom: 4 }}>Derived join/left events</h4>
+      {events.length === 0 ? (
+        <div style={{ color: "#666" }}>
+          Watching for changes. Join or leave a room to see events appear.
+        </div>
+      ) : (
+        <ul
+          id="presenceEvents"
+          style={{
+            margin: 0,
+            paddingLeft: 20,
+            maxHeight: 200,
+            overflowY: "auto",
+          }}
+        >
+          {events.map((e) => (
+            <li key={e.key}>
+              {new Date(e.at).toLocaleTimeString()} : {e.room} :{" "}
+              <strong>{e.type}</strong> {e.userName || "(no name)"}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/PresencePanel.tsx
+++ b/src/PresencePanel.tsx
@@ -13,6 +13,10 @@ const RECONCILE_INTERVAL_MS = 10_000;
 const WS_RETRY_MS = 2_000;
 const MAX_ROOMS = 10;
 const MAX_FEED = 50;
+// Presence data can trail reality by up to ~15s. Within this window we trust the
+// webhook (which is near-instant) over the presence snapshot, so a stale snapshot
+// can't resurrect someone who just left or drop someone who just joined.
+const PRESENCE_LAG_MS = 20_000;
 
 // One participant as returned by GET /presence.
 interface PresenceParticipant {
@@ -41,6 +45,9 @@ interface RosterParticipant {
   userName: string;
   room: string;
   joinTimeMs: number;
+  // When a webhook last touched this entry (0 if it came only from presence).
+  // Used so the reconcile won't override a recent webhook change with stale data.
+  lastWebhookMs: number;
 }
 
 type Roster = Record<string, RosterParticipant[]>;
@@ -71,6 +78,7 @@ function rosterFromPresence(data: PresenceResponse): Roster {
       userName: p.userName,
       room: p.room || room,
       joinTimeMs: Date.parse(p.joinTime),
+      lastWebhookMs: 0,
     }));
   }
   return roster;
@@ -105,6 +113,9 @@ export function PresencePanel(): ReactElement {
   // changes after we start watching, like a webhook consumer would.
   const seededRef = useRef(false);
   const eventIdRef = useRef(0);
+  // session keys (room:sessionId) a webhook removed recently, with the time. Used
+  // to stop a stale presence snapshot from resurrecting someone who just left.
+  const recentlyLeftRef = useRef<Map<string, number>>(new Map());
 
   const pushEvent = useCallback(
     (source: EventSource, kind: EventKind, room: string, userName: string) => {
@@ -135,32 +146,51 @@ export function PresencePanel(): ReactElement {
       }
       const data = (await res.json()) as PresenceResponse;
       const fresh = rosterFromPresence(data);
+      const nowMs = Date.now();
 
-      if (seededRef.current) {
-        // Diff against what we currently show, and log anything the webhook path
-        // missed as a "presence" event (the safety net catching a gap).
-        const freshByKey = new Map<string, RosterParticipant>();
-        for (const list of Object.values(fresh)) {
-          for (const p of list) freshByKey.set(rosterKey(p.room, p.sessionId), p);
-        }
-        const currentByKey = new Map<string, RosterParticipant>();
-        for (const list of Object.values(rosterRef.current)) {
-          for (const p of list)
-            currentByKey.set(rosterKey(p.room, p.sessionId), p);
-        }
-        for (const [key, p] of freshByKey) {
-          if (!currentByKey.has(key))
-            pushEvent("presence", "joined", p.room, p.userName);
-        }
-        for (const [key, p] of currentByKey) {
-          if (!freshByKey.has(key))
-            pushEvent("presence", "left", p.room, p.userName);
-        }
-      } else {
-        seededRef.current = true;
+      const freshByKey = new Map<string, RosterParticipant>();
+      for (const list of Object.values(fresh)) {
+        for (const p of list) freshByKey.set(rosterKey(p.room, p.sessionId), p);
+      }
+      const currentByKey = new Map<string, RosterParticipant>();
+      for (const list of Object.values(rosterRef.current)) {
+        for (const p of list) currentByKey.set(rosterKey(p.room, p.sessionId), p);
       }
 
-      setRoster(fresh);
+      // Forget stale entries in the recently-left guard.
+      for (const [key, leftMs] of recentlyLeftRef.current) {
+        if (nowMs - leftMs > PRESENCE_LAG_MS) recentlyLeftRef.current.delete(key);
+      }
+
+      // Merge presence into the webhook-driven roster. Webhooks win for recent
+      // changes: a stale presence snapshot must not resurrect someone a webhook
+      // just removed, nor drop someone a webhook just added. Presence only
+      // corrects drift older than the lag window.
+      const merged = new Map<string, RosterParticipant>();
+      for (const [key, cur] of currentByKey) {
+        if (freshByKey.has(key)) {
+          merged.set(key, cur); // present in both
+        } else if (nowMs - cur.lastWebhookMs < PRESENCE_LAG_MS) {
+          merged.set(key, cur); // presence lagging behind a recent webhook join
+        } else if (seededRef.current) {
+          pushEvent("presence", "left", cur.room, cur.userName); // real drift
+        }
+      }
+      for (const [key, p] of freshByKey) {
+        if (currentByKey.has(key)) continue;
+        const leftMs = recentlyLeftRef.current.get(key);
+        if (leftMs !== undefined && nowMs - leftMs < PRESENCE_LAG_MS) continue; // just left
+        merged.set(key, p);
+        if (seededRef.current) pushEvent("presence", "joined", p.room, p.userName);
+      }
+
+      seededRef.current = true;
+
+      const next: Roster = {};
+      for (const p of merged.values()) {
+        (next[p.room] ??= []).push(p);
+      }
+      setRoster(next);
       setLastReconcile(new Date().toLocaleTimeString());
       setError(null);
     } catch (err) {
@@ -175,20 +205,40 @@ export function PresencePanel(): ReactElement {
   // Apply one live webhook message to the roster.
   const handleWebhook = useCallback(
     (msg: WebhookMessage) => {
+      const key = rosterKey(msg.room, msg.session_id);
+      const nowMs = Date.now();
       if (msg.type === "participant.joined") {
+        recentlyLeftRef.current.delete(key);
         setRoster((prev) => {
-          const list = prev[msg.room] ? [...prev[msg.room]] : [];
-          if (list.some((p) => p.sessionId === msg.session_id)) return prev;
-          list.push({
-            sessionId: msg.session_id,
-            userName: msg.user_name,
-            room: msg.room,
-            joinTimeMs: msg.joined_at * 1000,
-          });
-          return { ...prev, [msg.room]: list };
+          const list = prev[msg.room] ?? [];
+          if (list.some((p) => p.sessionId === msg.session_id)) {
+            // Already present: just refresh the webhook recency stamp.
+            return {
+              ...prev,
+              [msg.room]: list.map((p) =>
+                p.sessionId === msg.session_id
+                  ? { ...p, lastWebhookMs: nowMs }
+                  : p,
+              ),
+            };
+          }
+          return {
+            ...prev,
+            [msg.room]: [
+              ...list,
+              {
+                sessionId: msg.session_id,
+                userName: msg.user_name,
+                room: msg.room,
+                joinTimeMs: msg.joined_at * 1000,
+                lastWebhookMs: nowMs,
+              },
+            ],
+          };
         });
         pushEvent("webhook", "joined", msg.room, msg.user_name);
       } else {
+        recentlyLeftRef.current.set(key, nowMs);
         setRoster((prev) => {
           const list = prev[msg.room];
           if (!list) return prev;

--- a/src/PresencePanel.tsx
+++ b/src/PresencePanel.tsx
@@ -1,8 +1,16 @@
-import { type ReactElement, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
-// Poll no more than once every 15s (per the Presence API docs); data can lag up
-// to 15s behind reality.
-const POLL_INTERVAL_MS = 15_000;
+// The Presence API can lag up to ~15s and we reconcile every 10s. Webhooks fill
+// the gap: they arrive within a second or two, so the roster updates live.
+const RECONCILE_INTERVAL_MS = 10_000;
+const WS_RETRY_MS = 2_000;
 const MAX_ROOMS = 10;
 const MAX_FEED = 50;
 
@@ -10,165 +18,257 @@ const MAX_FEED = 50;
 interface PresenceParticipant {
   room: string;
   id: string;
-  userId: string | null;
   userName: string;
-  mtgSessionId: string;
   joinTime: string;
-  duration: number;
 }
 
 // GET /presence returns a map of room name -> currently present participants.
 type PresenceResponse = Record<string, PresenceParticipant[]>;
 
-interface PresenceRoom {
+// A live message pushed by our server over the WebSocket, one per webhook event.
+interface WebhookMessage {
+  type: "participant.joined" | "participant.left";
   room: string;
-  participants: PresenceParticipant[];
-  latestJoin: number;
+  session_id: string;
+  user_name: string;
+  joined_at: number;
+  duration?: number;
 }
 
-type PresenceEventType = "joined" | "left";
+// Normalized participant used in the roster, from either source.
+interface RosterParticipant {
+  sessionId: string;
+  userName: string;
+  room: string;
+  joinTimeMs: number;
+}
+
+type Roster = Record<string, RosterParticipant[]>;
+
+type EventSource = "webhook" | "presence";
+type EventKind = "joined" | "left";
 
 interface DerivedEvent {
   key: string;
-  type: PresenceEventType;
+  kind: EventKind;
+  source: EventSource;
   room: string;
   userName: string;
   at: string;
 }
 
-// A stable key for one participant in one room, so the same id in two rooms is
-// treated as two distinct people.
-function participantKey(p: PresenceParticipant): string {
-  return `${p.room}:${p.id}`;
+type WsStatus = "connecting" | "live" | "closed";
+
+function rosterKey(room: string, sessionId: string): string {
+  return `${room}:${sessionId}`;
+}
+
+function rosterFromPresence(data: PresenceResponse): Roster {
+  const roster: Roster = {};
+  for (const [room, participants] of Object.entries(data)) {
+    roster[room] = participants.map((p) => ({
+      sessionId: p.id,
+      userName: p.userName,
+      room: p.room || room,
+      joinTimeMs: Date.parse(p.joinTime),
+    }));
+  }
+  return roster;
 }
 
 /**
- * Presence API demo.
+ * Hybrid presence + webhooks demo.
  *
- * Instead of consuming participant.joined / participant.left webhooks, this
- * polls the /presence REST endpoint every 15s, renders a live roster of the 10
- * most recently active rooms, and derives synthetic "joined" / "left" events by
- * diffing each snapshot against the previous one. That diff is the direct
- * replacement for the two webhooks.
+ * This is the pattern we recommend when you need a live roster:
+ * - Presence API for the snapshot on load and a full reconcile every 10s (the
+ *   authoritative safety net).
+ * - Webhooks (participant.joined / participant.left) pushed from our server over
+ *   a WebSocket for the fast "in between" updates.
  *
- * The domain API key is never in the browser: the request goes to /api/presence,
- * which the Vite dev server proxies to api.daily.co with the Authorization
- * header added server-side (see vite.config.ts).
+ * The domain API key and webhook hmac live on the server (see server/index.ts).
+ * The browser only calls /api/presence and connects to /ws.
  */
 export function PresencePanel(): ReactElement {
-  const [rooms, setRooms] = useState<PresenceRoom[]>([]);
+  const [roster, setRoster] = useState<Roster>({});
   const [events, setEvents] = useState<DerivedEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [lastReconcile, setLastReconcile] = useState<string | null>(null);
+  const [wsStatus, setWsStatus] = useState<WsStatus>("connecting");
 
-  // Previous snapshot, keyed by `${room}:${id}`, used to diff for join/left.
-  const prevRef = useRef<Map<string, PresenceParticipant>>(new Map());
-  // Skip event generation on the first successful poll: we only report changes
-  // that happen after we start listening, the same as a webhook consumer would.
+  // Mirror of roster for diffing during reconcile, kept in sync after each render.
+  const rosterRef = useRef<Roster>({});
+  useEffect(() => {
+    rosterRef.current = roster;
+  }, [roster]);
+
+  // Skip event logging on the first reconcile (the initial snapshot); only report
+  // changes after we start watching, like a webhook consumer would.
   const seededRef = useRef(false);
+  const eventIdRef = useRef(0);
 
-  const fetchPresence = useCallback(async (): Promise<void> => {
-    setLoading(true);
+  const pushEvent = useCallback(
+    (source: EventSource, kind: EventKind, room: string, userName: string) => {
+      const at = new Date().toISOString();
+      eventIdRef.current += 1;
+      const event: DerivedEvent = {
+        key: `${String(eventIdRef.current)}`,
+        kind,
+        source,
+        room,
+        userName,
+        at,
+      };
+      setEvents((prev) => [event, ...prev].slice(0, MAX_FEED));
+    },
+    [],
+  );
+
+  // Presence reconcile: the authoritative full snapshot.
+  const reconcile = useCallback(async (): Promise<void> => {
     try {
       const res = await fetch("/api/presence", {
         headers: { "Content-Type": "application/json" },
       });
-
       if (!res.ok) {
-        if (res.status === 401 || res.status === 400) {
-          setError(
-            "Auth failed (check DAILY_API_KEY in .env.local, then restart the dev server).",
-          );
-        } else if (res.status === 429) {
-          setError("Rate limited by the Presence API. Polling will retry.");
-        } else {
-          setError(`Presence request failed: HTTP ${res.status}.`);
-        }
+        setError(`Presence request failed: HTTP ${String(res.status)}.`);
         return;
       }
-
       const data = (await res.json()) as PresenceResponse;
+      const fresh = rosterFromPresence(data);
 
-      // Flatten the current snapshot into a keyed map.
-      const currentMap = new Map<string, PresenceParticipant>();
-      for (const participants of Object.values(data)) {
-        for (const p of participants) {
-          currentMap.set(participantKey(p), p);
-        }
-      }
-
-      // Diff against the previous snapshot to derive joined/left events.
       if (seededRef.current) {
-        const now = new Date().toISOString();
-        const newEvents: DerivedEvent[] = [];
-
-        for (const [key, p] of currentMap) {
-          if (!prevRef.current.has(key)) {
-            console.log("presence: joined", { room: p.room, participant: p });
-            newEvents.push({
-              key: `${key}:joined:${now}`,
-              type: "joined",
-              room: p.room,
-              userName: p.userName,
-              at: now,
-            });
-          }
+        // Diff against what we currently show, and log anything the webhook path
+        // missed as a "presence" event (the safety net catching a gap).
+        const freshByKey = new Map<string, RosterParticipant>();
+        for (const list of Object.values(fresh)) {
+          for (const p of list) freshByKey.set(rosterKey(p.room, p.sessionId), p);
         }
-        for (const [key, p] of prevRef.current) {
-          if (!currentMap.has(key)) {
-            console.log("presence: left", { room: p.room, participant: p });
-            newEvents.push({
-              key: `${key}:left:${now}`,
-              type: "left",
-              room: p.room,
-              userName: p.userName,
-              at: now,
-            });
-          }
+        const currentByKey = new Map<string, RosterParticipant>();
+        for (const list of Object.values(rosterRef.current)) {
+          for (const p of list)
+            currentByKey.set(rosterKey(p.room, p.sessionId), p);
         }
-
-        if (newEvents.length > 0) {
-          setEvents((prev) => [...newEvents, ...prev].slice(0, MAX_FEED));
+        for (const [key, p] of freshByKey) {
+          if (!currentByKey.has(key))
+            pushEvent("presence", "joined", p.room, p.userName);
+        }
+        for (const [key, p] of currentByKey) {
+          if (!freshByKey.has(key))
+            pushEvent("presence", "left", p.room, p.userName);
         }
       } else {
         seededRef.current = true;
       }
 
-      prevRef.current = currentMap;
-
-      // Rank rooms by their most recent participant joinTime, keep the top 10.
-      const rankedRooms: PresenceRoom[] = Object.entries(data)
-        .map(([room, participants]) => ({
-          room,
-          participants,
-          latestJoin: participants.reduce(
-            (max, p) => Math.max(max, new Date(p.joinTime).getTime()),
-            0,
-          ),
-        }))
-        .sort((a, b) => b.latestJoin - a.latestJoin)
-        .slice(0, MAX_ROOMS);
-
-      setRooms(rankedRooms);
-      setLastUpdated(new Date().toLocaleTimeString());
+      setRoster(fresh);
+      setLastReconcile(new Date().toLocaleTimeString());
       setError(null);
     } catch (err) {
       setError(
-        `Could not reach the Presence proxy: ${
+        `Could not reach the presence backend: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
-    } finally {
-      setLoading(false);
     }
+  }, [pushEvent]);
+
+  // Apply one live webhook message to the roster.
+  const handleWebhook = useCallback(
+    (msg: WebhookMessage) => {
+      if (msg.type === "participant.joined") {
+        setRoster((prev) => {
+          const list = prev[msg.room] ? [...prev[msg.room]] : [];
+          if (list.some((p) => p.sessionId === msg.session_id)) return prev;
+          list.push({
+            sessionId: msg.session_id,
+            userName: msg.user_name,
+            room: msg.room,
+            joinTimeMs: msg.joined_at * 1000,
+          });
+          return { ...prev, [msg.room]: list };
+        });
+        pushEvent("webhook", "joined", msg.room, msg.user_name);
+      } else {
+        setRoster((prev) => {
+          const list = prev[msg.room];
+          if (!list) return prev;
+          const next = list.filter((p) => p.sessionId !== msg.session_id);
+          const copy = { ...prev };
+          if (next.length > 0) copy[msg.room] = next;
+          else delete copy[msg.room];
+          return copy;
+        });
+        pushEvent("webhook", "left", msg.room, msg.user_name);
+      }
+    },
+    [pushEvent],
+  );
+
+  // Initial snapshot + periodic reconcile.
+  useEffect(() => {
+    void reconcile();
+    const interval = setInterval(() => void reconcile(), RECONCILE_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [reconcile]);
+
+  // WebSocket for live webhook events, with auto-reconnect.
+  const wsUrl = useMemo(() => {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return `${proto}//${window.location.host}/ws`;
   }, []);
 
   useEffect(() => {
-    void fetchPresence();
-    const interval = setInterval(() => void fetchPresence(), POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [fetchPresence]);
+    let unmounted = false;
+    let socket: WebSocket | null = null;
+    let retry: number | undefined;
+
+    const connect = (): void => {
+      setWsStatus("connecting");
+      socket = new WebSocket(wsUrl);
+      socket.onopen = () => setWsStatus("live");
+      socket.onmessage = (ev: MessageEvent) => {
+        try {
+          const msg = JSON.parse(ev.data as string) as WebhookMessage;
+          handleWebhook(msg);
+        } catch {
+          // ignore malformed messages
+        }
+      };
+      socket.onclose = () => {
+        setWsStatus("closed");
+        if (!unmounted) retry = window.setTimeout(connect, WS_RETRY_MS);
+      };
+      socket.onerror = () => socket?.close();
+    };
+    connect();
+
+    return () => {
+      unmounted = true;
+      if (retry) clearTimeout(retry);
+      socket?.close();
+    };
+  }, [wsUrl, handleWebhook]);
+
+  const rankedRooms = useMemo(() => {
+    return Object.entries(roster)
+      .map(([room, participants]) => ({
+        room,
+        participants,
+        latestJoin: participants.reduce(
+          (max, p) => Math.max(max, p.joinTimeMs),
+          0,
+        ),
+      }))
+      .sort((a, b) => b.latestJoin - a.latestJoin)
+      .slice(0, MAX_ROOMS);
+  }, [roster]);
+
+  const wsLabel =
+    wsStatus === "live"
+      ? "live"
+      : wsStatus === "connecting"
+        ? "connecting…"
+        : "closed (retrying)";
 
   return (
     <div
@@ -178,7 +278,7 @@ export function PresencePanel(): ReactElement {
         borderRadius: 8,
         padding: 12,
         marginTop: 16,
-        maxWidth: 600,
+        maxWidth: 640,
       }}
     >
       <div
@@ -189,15 +289,15 @@ export function PresencePanel(): ReactElement {
           gap: 8,
         }}
       >
-        <strong>Presence API: {MAX_ROOMS} most recent rooms</strong>
-        <button type="button" onClick={() => void fetchPresence()}>
-          Refresh presence
+        <strong>Presence + webhooks: {MAX_ROOMS} most recent rooms</strong>
+        <button type="button" onClick={() => void reconcile()}>
+          Refresh now
         </button>
       </div>
 
       <div style={{ fontSize: 12, color: "#666", marginTop: 4 }}>
-        Polls /api/presence every 15s. Last updated: {lastUpdated ?? "never"}
-        {loading ? " (refreshing…)" : ""}
+        Webhook stream: <strong>{wsLabel}</strong> · Presence reconcile every 10s
+        · Last reconcile: {lastReconcile ?? "never"}
       </div>
 
       {error && (
@@ -207,21 +307,21 @@ export function PresencePanel(): ReactElement {
       )}
 
       <h4 style={{ marginBottom: 4 }}>Rooms</h4>
-      {rooms.length === 0 ? (
+      {rankedRooms.length === 0 ? (
         <div style={{ color: "#666" }}>
           No active rooms on this domain yet. Join a room to see presence here.
         </div>
       ) : (
-        rooms.map((r) => (
+        rankedRooms.map((r) => (
           <div key={r.room} style={{ marginBottom: 8 }}>
             <div>
               <strong>{r.room}</strong> ({r.participants.length})
             </div>
             <ul style={{ margin: "4px 0", paddingLeft: 20 }}>
               {r.participants.map((p) => (
-                <li key={p.id}>
-                  {p.userName || "(no name)"} : {p.id} : joined{" "}
-                  {new Date(p.joinTime).toLocaleTimeString()} : {p.duration}s
+                <li key={p.sessionId}>
+                  {p.userName || "(no name)"} : {p.sessionId} : joined{" "}
+                  {new Date(p.joinTimeMs).toLocaleTimeString()}
                 </li>
               ))}
             </ul>
@@ -229,7 +329,7 @@ export function PresencePanel(): ReactElement {
         ))
       )}
 
-      <h4 style={{ marginBottom: 4 }}>Derived join/left events</h4>
+      <h4 style={{ marginBottom: 4 }}>Join/left events</h4>
       {events.length === 0 ? (
         <div style={{ color: "#666" }}>
           Watching for changes. Join or leave a room to see events appear.
@@ -246,8 +346,18 @@ export function PresencePanel(): ReactElement {
         >
           {events.map((e) => (
             <li key={e.key}>
-              {new Date(e.at).toLocaleTimeString()} : {e.room} :{" "}
-              <strong>{e.type}</strong> {e.userName || "(no name)"}
+              {new Date(e.at).toLocaleTimeString()} :{" "}
+              <span
+                style={{
+                  fontSize: 11,
+                  padding: "0 4px",
+                  borderRadius: 4,
+                  background: e.source === "webhook" ? "#e6f0ff" : "#eee",
+                }}
+              >
+                {e.source}
+              </span>{" "}
+              {e.room} : <strong>{e.kind}</strong> {e.userName || "(no name)"}
             </li>
           ))}
         </ul>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { Prebuilt } from "./Prebuilt";
 import { DailyProvider } from "@daily-co/daily-react";
 import App from "./App";
+import { PresencePage } from "./PresencePage";
 
 const container = document.getElementById("root");
 
@@ -15,18 +16,23 @@ const root = createRoot(container);
 // Get the value from the url
 const urlParams = new URLSearchParams(window.location.search);
 const isPrebuilt = urlParams.get("prebuilt") ?? false;
+const isKitchenSink = urlParams.get("kitchensink") ?? false;
 
+// The presence + webhooks page is the default. The full kitchen-sink App is at
+// ?kitchensink=true, and Daily Prebuilt at ?prebuilt=true.
 root.render(
   <StrictMode>
     {isPrebuilt ? (
       <Prebuilt />
-    ) : (
+    ) : isKitchenSink ? (
       <DailyProvider
         subscribeToTracksAutomatically={false}
         dailyConfig={{ useDevicePreferenceCookies: true }}
       >
         <App />
       </DailyProvider>
+    ) : (
+      <PresencePage />
     )}
   </StrictMode>
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,35 +1,19 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
-  // Load all env vars (the "" prefix includes non-VITE_ keys). DAILY_API_KEY is
-  // read here in the Node dev server only, so it never lands in the client bundle.
-  const env = loadEnv(mode, process.cwd(), "");
-
-  return {
-    base: "/",
-    server: {
-      port: 3000,
-      // Proxy the Presence REST API through the dev server so the domain API key
-      // stays server-side. The browser calls /api/presence with no auth header;
-      // we add the Bearer token here before forwarding to api.daily.co.
-      proxy: {
-        "/api/presence": {
-          target: "https://api.daily.co/v1",
-          changeOrigin: true,
-          rewrite: () => "/presence",
-          configure: (proxy) => {
-            proxy.on("proxyReq", (proxyReq) => {
-              proxyReq.setHeader(
-                "Authorization",
-                `Bearer ${env.DAILY_API_KEY ?? ""}`,
-              );
-            });
-          },
-        },
-      },
+// The Presence + webhooks demo needs a backend (see server/index.ts) to hold the
+// API key, receive Daily webhooks, and push events over a WebSocket. Run it with
+// `npm run server` (or `npm run dev:all`). Vite proxies /api and /ws to it, so
+// the browser never talks to api.daily.co and never sees the API key.
+export default defineConfig({
+  base: "/",
+  server: {
+    port: 3000,
+    proxy: {
+      "/api": { target: "http://localhost:4000", changeOrigin: true },
+      "/ws": { target: "http://localhost:4000", ws: true },
     },
-    plugins: [react()],
-  };
+  },
+  plugins: [react()],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,35 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: "/",
-  server: {
-    port: 3000,
-  },
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  // Load all env vars (the "" prefix includes non-VITE_ keys). DAILY_API_KEY is
+  // read here in the Node dev server only, so it never lands in the client bundle.
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    base: "/",
+    server: {
+      port: 3000,
+      // Proxy the Presence REST API through the dev server so the domain API key
+      // stays server-side. The browser calls /api/presence with no auth header;
+      // we add the Bearer token here before forwarding to api.daily.co.
+      proxy: {
+        "/api/presence": {
+          target: "https://api.daily.co/v1",
+          changeOrigin: true,
+          rewrite: () => "/presence",
+          configure: (proxy) => {
+            proxy.on("proxyReq", (proxyReq) => {
+              proxyReq.setHeader(
+                "Authorization",
+                `Bearer ${env.DAILY_API_KEY ?? ""}`,
+              );
+            });
+          },
+        },
+      },
+    },
+    plugins: [react()],
+  };
 });


### PR DESCRIPTION
## Summary

Keeps a live roster of who is in your Daily rooms using two sources together, the pattern we recommend when webhook delivery timing matters:

- **Presence API** ([`/presence`](https://docs.daily.co/reference/rest-api/presence)) for the snapshot on page load and a full reconcile every 10s (the authoritative safety net).
- **Webhooks** ([`participant.joined` / `participant.left`](https://docs.daily.co/reference/rest-api/webhooks)) pushed from a small backend to the browser over a WebSocket for the fast in-between updates (roster changes in ~1-2s instead of waiting for the next poll).

Presence gives correctness, webhooks give speed. Each event in the panel is tagged with its source (`webhook` or `presence`) so the difference is visible.

### How it fits together

```
Browser (PresencePanel)
  GET /api/presence   -> snapshot on load + reconcile every 10s
  WebSocket /ws       <- live joined/left pushed by the server
        |
Vite dev server  -- proxies /api and /ws -->  Node server (server/index.ts)
                                                holds DAILY_API_KEY, calls /presence
                                                POST /api/daily-webhook  <- Daily (via ngrok)
                                                verifies the hmac, 200 fast, broadcasts on /ws
```

- New Node backend in `server/*.ts`, run directly by Node 24 (native type stripping, no build step): presence proxy, webhook receiver (HMAC verification + the create-time `{"test":"test"}` handshake + fast 200), and WebSocket broadcast.
- `server/register-webhook.ts` CLI: `create` / `--update` / `--list` / `--delete`. Handles the one-webhook-per-domain limit with an update path.
- `PresencePanel` reworked: snapshot on load, live webhook events over the socket, 10s presence reconcile as the safety net, WebSocket status line with auto-reconnect.
- The domain API key and webhook hmac stay server-side. The browser only calls `/api/presence` and `/ws`; neither secret is in the client bundle.

## Prerequisites

- `DAILY_API_KEY` in `.env.local` (from [dashboard.daily.co/developers](https://dashboard.daily.co/developers)).
- A public tunnel for the webhook receiver (e.g. ngrok). Register with `server/register-webhook.ts`, paste the returned hmac into `.env.local` as `DAILY_WEBHOOK_HMAC`, restart the server. Full steps in the README.
- This is a local dev setup. In production the receiver and WebSocket run on your own backend.

## Test plan

- `npm run build` (tsc + vite) passes; `npm test` (eslint) clean; `npm run typecheck:server` clean.
- `npm run test:server` (node --test) passes 4 HMAC verification cases (valid, tampered body, wrong timestamp, wrong secret).
- API key and hmac confirmed absent from the client bundle (grep `dist/` after build).
- **End-to-end with a real Daily webhook** (ngrok + real join/leave): registered the webhook against an ngrok tunnel, joined a room in a browser, and confirmed the server received `participant.joined`, verified the HMAC, and broadcast it over the WebSocket to a client. Leaving produced a matching `participant.left` for the same session. The full chain (Daily -> ngrok -> receiver -> verify -> WebSocket -> client) works.
